### PR TITLE
fix: pass detective config through cloning

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,10 @@ module.exports._getDependencies = function(config) {
   var precinctOptions = config.detectiveConfig;
   precinctOptions.includeCore = false;
 
+  // TODO: Avoid introducing language knowledge here
+  precinctOptions.sass = precinctOptions.sass || {};
+  precinctOptions.sass.syntax = path.extname(config.filename).replace('.', '');
+
   try {
     dependencies = precinct.paperwork(config.filename, precinctOptions);
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Config(options) {
   this.isListForm = options.isListForm;
   this.requireConfig = options.config || options.requireConfig;
   this.webpackConfig = options.webpackConfig;
-  this.detectiveConfig = options.detective || {};
+  this.detectiveConfig = options.detective || options.detectiveConfig || {};
 
   this.filter = options.filter;
 


### PR DESCRIPTION
Cloning passes the current config into itself. The detectiveConfig own prop didn't match the expected detective option prop. 

Tests coming in a follow up.