### PR TITLE
Pass in the traversed filepath to the filter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,7 @@ var list = dependencyTree.toList({
 * `visited`: object used for avoiding redundant subtree generations via memoization.
 * `nonExistent`: array used for storing the list of partial paths that do not exist
 * `filter`: a function used to determine if a module (and its subtree) should be included in the dependency tree
- - The function should accept an absolute filepath and return a boolean
- - If the filter returns true, the module is included in the resulting tree
+ - The first argument given to the filter is an absolute filepath to the dependency and the second is the filepath to the currently traversed file. Should return a `Boolean`. If it returns `true`, the module is included in the resulting tree.
 * `detective`: object with configuration specific to detectives used to find dependencies of a file
  - for example `detective.amd.skipLazyLoaded: true` tells the AMD detective to omit inner requires
  - See [precinct's usage docs](https://github.com/dependents/node-precinct#usage) for the list of module types you can pass options to.

--- a/index.js
+++ b/index.js
@@ -152,7 +152,9 @@ function traverse(config) {
   if (config.filter) {
     debug('using filter function to filter out dependencies');
     debug('unfiltered number of dependencies: ' + dependencies.length);
-    dependencies = dependencies.filter(config.filter);
+    dependencies = dependencies.filter(function(filePath) {
+      return config.filter(filePath, config.filename);
+    });
     debug('filtered number of dependencies: ' + dependencies.length);
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -671,7 +671,11 @@ describe('dependencyTree', function() {
         filename,
         directory,
         // Skip all 3rd party deps
-        filter: (path) => path.indexOf('node_modules') === -1
+        filter: (filePath, moduleFile) => {
+          assert.ok(filePath.match('node_modules/debug/node.js'));
+          assert.ok(moduleFile.match('test/example/onlyRealDeps/a.js'));
+          return filePath.indexOf('node_modules') === -1;
+        }
       });
 
       const subTree = tree[filename];


### PR DESCRIPTION
I need this in Madge to be able to get info about used NPM dependencies in modules without having to traverse the entire node_modules folder.

See https://github.com/pahen/madge/issues/112