### PR TITLE
chore: upgrade precinct version to 4.0.0 to address warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+    - "lts/*"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "lts/*"
+    - "7"
 
 notifications:
   email: false

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var precinct = require('precinct');
-var path = require('path');
 var fs = require('fs');
 var cabinet = require('filing-cabinet');
 var debug = require('debug')('tree');

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "precinct": "^4.0.0"
   },
   "devDependencies": {
-    "babel": "~5.8.38",
-    "jscs": "~2.11.0",
+    "babel-cli": "~6.26.0",
+    "jscs": "~3.0.7",
     "jscs-preset-mrjoelkemp": "~1.0.0",
-    "mocha": "~2.0.1",
+    "mocha": "~5.0.0",
     "mock-fs": "~4.4.2",
-    "rewire": "~2.5.2",
-    "sinon": "~1.12.2"
+    "rewire": "~3.0.2",
+    "sinon": "~4.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
     "mocha": "~2.0.1",
-    "mock-fs": "~3.11.0",
+    "mock-fs": "~4.4.2",
     "rewire": "~2.5.2",
     "sinon": "~1.12.2"
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "commander": "^2.6.0",
     "debug": "^3.1.0",
     "filing-cabinet": "^1.12.0",
-    "precinct": "^3.8.0"
+    "precinct": "^4.0.0"
   },
   "devDependencies": {
     "babel": "~5.8.38",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,13 @@
     "precinct": "^4.0.0"
   },
   "devDependencies": {
-    "babel-cli": "~6.26.0",
-    "jscs": "~3.0.7",
+    "babel": "~5.8.38",
+    "jscs": "~2.11.0",
     "jscs-preset-mrjoelkemp": "~1.0.0",
-    "mocha": "~5.0.0",
+    "mocha": "~2.0.1",
     "mock-fs": "~4.4.2",
-    "rewire": "~3.0.2",
-    "sinon": "~4.1.6"
+    "rewire": "~2.5.2",
+    "sinon": "~4.1.6",
+    "resolve": "~1.5.0"
   }
 }


### PR DESCRIPTION
npm i gives the following warning (among others):

```console
npm WARN typescript-eslint-parser@1.0.2 requires a peer of typescript@~2.0.3 but none is installed. You must install peer dependencies yourself.
```

Updating to precinct 4, fixes this one though. FYI 

