### PR TITLE
Only transpile code not supported by the lowest supported node version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [ "env" ]
+  "presets": [ [ "env", { "targets": { "node": "6" } } ] ]
 }


### PR DESCRIPTION
Doesn't make a massive difference as it's only used for the tests.