### PR TITLE
Upgrading version on filing-cabinet to avoid v1.14.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "commander": "^2.16.0",
     "debug": "^3.1.0",
-    "filing-cabinet": "^1.14.2",
+    "filing-cabinet": "^2.0.1",
     "precinct": "^4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Filing-cabinet v1.14.4 has an issue when trying to reassign a constant variable. This issue was fixed on v2.0.1
Upgrading filing-cabinet version will prevent this issue from erroring.