### PR TITLE
Remove unnecessary files and folders in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "node": ">=6.0.0"
   },
   "homepage": "https://github.com/mrjoelkemp/node-dependency-tree",
+  "files": [
+    "bin",
+    "lib"
+  ],
   "dependencies": {
     "commander": "^2.19.0",
     "debug": "^4.1.1",


### PR DESCRIPTION
Hi,

First, thanks for your good work!

Currently, the published package on npm contains a lot of unnecessary files and folders. To reduce the package size, I think only `index.js`, `bin` and `lib` folders must be included. This PR adds the [files](https://docs.npmjs.com/files/package.json#files) property to the `package.json` to specify the folders and files included in the final package (the file in the `main` field is always included).

Here is the output of the `npm pack --dry-run` command:

```shell
npm notice === Tarball Contents ===
npm notice 1.4kB package.json
npm notice 5.8kB index.js
npm notice 1.1kB LICENSE
npm notice 7.6kB README.md
npm notice 1.0kB bin/cli.js
npm notice 1.2kB lib/Config.js
npm notice === Tarball Details ===
```

 Here is the output of the `npm pack dependency-tree --dry-run` command, showing the files included in the published package:

```shell
npm notice === Tarball Contents ===
npm notice 1.4kB  package.json
npm notice 70B    .babelrc
npm notice 18B    .deprc
npm notice 28B    .jscsrc
npm notice 89B    .travis.yml
npm notice 5.8kB  index.js
npm notice 1.1kB  LICENSE
npm notice 7.6kB  README.md
npm notice 137B   webpack.config.js
npm notice 1.0kB  bin/cli.js
npm notice 1.2kB  lib/Config.js
npm notice 84B    test/example/amd/a.js
npm notice 67B    test/example/amd/b.js
npm notice 12B    test/example/amd/c.js
npm notice 48B    test/example/commonjs/a.js
npm notice 50B    test/example/commonjs/b.js
npm notice 46B    test/example/commonjs/c.js
npm notice 48B    test/example/extended/a.js
npm notice 48B    test/example/extended/b.js
npm notice 48B    test/example/extended/c.js
npm notice 0      test/example/extended/d.js
npm notice 0      test/example/extended/e.js
npm notice 0      test/example/extended/f.js
npm notice 0      test/example/extended/g.js
npm notice 92B    test/example/onlyRealDeps/a.js
npm notice 78B    test/example/ts/.tsconfig
npm notice 42B    test/example/ts/a.ts
npm notice 30B    test/example/ts/b.ts
npm notice 30B    test/example/ts/c.ts
npm notice 52B    test/example/ts/d.tsx
npm notice 23B    test/example/webpack/aliased.js
npm notice 40B    test/example/webpack/unaliased.js
npm notice 25.0kB test/test.js
npm notice === Tarball Details ===
```

