### PR TITLE
Add option to store package names in result tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,17 +228,25 @@ function dedupeNonExistent(nonExistent) {
  * @return {String}
  */
 function getPakcageId(config) {
+  console.log(config.filename);
   const directoryList = config.filename.split(path.sep);
-  while (directoryList.length > 2 && directoryList[directoryList.length - 2] !== 'node_modules') {
-    directoryList.pop();
+  if (directoryList.includes('node_modules')) {
+    let i = 0;
+    while (directoryList.length > 0 && directoryList[directoryList.length - 1] !== 'node_modules') {
+      const pkgPath = directoryList.join(path.sep).concat(path.sep, 'package.json');
+      if (pkgPath.includes('@types')) console.log('NESTED YES');
+      if (fs.existsSync(pkgPath)) {
+        const pkgFile = fs.readFileSync(pkgPath);
+        const pkgName = JSON.parse(pkgFile)['name'];
+        const pkgVersion = JSON.parse(pkgFile)['version'];
+        const pkgId = pkgName.concat('@' + pkgVersion);
+        config.pkgId = pkgId;
+        return pkgId;
+      }
+      directoryList.pop();
+      ++i;
+    }
   }
-  const pkgPath = directoryList.join(path.sep).concat('/', 'package.json');
-  if (!fs.existsSync(pkgPath)) {
-    debug('package.json does not exist');
-    return '';
-  }
-  const pkgFile = fs.readFileSync(pkgPath);
-  const pkgId = JSON.parse(pkgFile)['_id'];
-  config.pkgId = pkgId;
-  return pkgId;
+  debug('package.json does not exist');
+  return '';
 }

--- a/index.js
+++ b/index.js
@@ -189,9 +189,7 @@ function traverse(config) {
       }
     } else if (localConfig.isPackageForm) {
       for (let item of traverse(localConfig)) {
-        if (item && item.length > 0) {
-          subTree.add(item);
-        }
+        subTree.add(item);
       }
     } else {
       subTree[d] = traverse(localConfig);

--- a/index.js
+++ b/index.js
@@ -152,29 +152,29 @@ module.exports._getDependencies = function (config) {
 function traverse(config) {
   let subTree = config.isListForm || config.isPackageForm ? new Set() : {};
 
-  console.log('\ntraversing ' + config.filename);
+  debug('\ntraversing ' + config.filename);
 
 
 
   if (config.visited[config.filename]) {
-    console.log('already visited ' + config.filename);
+    debug('already visited ' + config.filename);
     return config.visited[config.filename];
   }
 
   let dependencies = module.exports._getDependencies(config);
 
-  // console.log('cabinet-resolved all dependencies: ', dependencies);
+  debug('cabinet-resolved all dependencies: ', dependencies);
   // Prevents cycles by eagerly marking the current file as read
   // so that any dependent dependencies exit
   config.visited[config.filename] = config.isListForm || config.isPackageForm ? [] : {};
 
   if (config.filter) {
-    console.log('using filter function to filter out dependencies');
-    console.log('unfiltered number of dependencies: ' + dependencies.length);
+    debug('using filter function to filter out dependencies');
+    debug('unfiltered number of dependencies: ' + dependencies.length);
     dependencies = dependencies.filter(function (filePath) {
       return config.filter(filePath, config.filename);
     });
-    console.log('filtered number of dependencies: ' + dependencies.length);
+    debug('filtered number of dependencies: ' + dependencies.length);
   }
 
   for (let i = 0, l = dependencies.length; i < l; i++) {
@@ -199,11 +199,11 @@ function traverse(config) {
   }
 
   if (config.isListForm) {
-    console.log('NEW FILE FOUND', config.filename);
+    debug('NEW FILE FOUND', config.filename);
     subTree.add(config.filename);
     config.visited[config.filename].push(...subTree);
   } else if (config.isPackageForm) {
-    console.log('NEW PACKAGE FOUND:', config.pkgId);
+    debug('NEW PACKAGE FOUND:', config.pkgId);
     subTree.add(config.pkgId);
     config.visited[config.filename].push(...subTree);
   } else {
@@ -232,7 +232,7 @@ function getPakcageId(config) {
   }
   const pkgPath = directoryList.join(path.sep).concat('/', 'package.json');
   if (!fs.existsSync(pkgPath)) {
-    console.log('package.json does not exist');
+    debug('package.json does not exist');
     return [];
   }
   const pkgFile = fs.readFileSync(pkgPath);

--- a/index.js
+++ b/index.js
@@ -49,7 +49,9 @@ module.exports = function (options) {
   } else if (config.isPackageForm) {
     debug('package form of results requested');
 
-    tree = Array.from(results);
+    tree = Array.from(results).filter((item) => {
+      return item != '';
+    });
   } else {
     debug('object form of results requested');
 
@@ -187,7 +189,7 @@ function traverse(config) {
       }
     } else if (localConfig.isPackageForm) {
       for (let item of traverse(localConfig)) {
-        if (item.length > 0) {
+        if (item && item.length > 0) {
           subTree.add(item);
         }
       }
@@ -237,7 +239,7 @@ function getPakcageId(config) {
   const pkgPath = directoryList.join(path.sep).concat('/', 'package.json');
   if (!fs.existsSync(pkgPath)) {
     debug('package.json does not exist');
-    return [];
+    return '';
   }
   const pkgFile = fs.readFileSync(pkgPath);
   const pkgId = JSON.parse(pkgFile)['_id'];

--- a/index.js
+++ b/index.js
@@ -154,8 +154,6 @@ function traverse(config) {
 
   debug('\ntraversing ' + config.filename);
 
-
-
   if (config.visited[config.filename]) {
     debug('already visited ' + config.filename);
     return config.visited[config.filename];
@@ -225,6 +223,12 @@ function dedupeNonExistent(nonExistent) {
   }
 }
 
+/**
+ * Get the "_id" value in package.json file of a JavaScript module which is its module name and version
+ *
+ * @param {Config} config
+ * @return {String}
+ */
 function getPakcageId(config) {
   const directoryList = config.filename.split(path.sep);
   while (directoryList.length > 2 && directoryList[directoryList.length - 2] !== 'node_modules') {

--- a/index.js
+++ b/index.js
@@ -197,11 +197,9 @@ function traverse(config) {
   }
 
   if (config.isListForm) {
-    debug('NEW FILE FOUND', config.filename);
     subTree.add(config.filename);
     config.visited[config.filename].push(...subTree);
   } else if (config.isPackageForm) {
-    debug('NEW PACKAGE FOUND:', config.pkgId);
     subTree.add(config.pkgId);
     config.visited[config.filename].push(...subTree);
   } else {

--- a/index.js
+++ b/index.js
@@ -228,7 +228,6 @@ function dedupeNonExistent(nonExistent) {
  * @return {String}
  */
 function getPakcageId(config) {
-  console.log(config.filename);
   const directoryList = config.filename.split(path.sep);
   if (directoryList.includes('node_modules')) {
     let i = 0;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -22,7 +22,6 @@ class Config {
 
     if (!this.filename) { throw new Error('filename not given'); }
     if (!this.directory) { throw new Error('directory not given'); }
-    // if (!this.pkgId) { throw new Error('package ID not given'); }
     if (this.filter && typeof this.filter !== 'function') { throw new Error('filter must be a function'); }
 
     if ('string' === typeof this.tsConfig) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -7,9 +7,11 @@ class Config {
   constructor(options) {
     this.filename = options.filename;
     this.directory = options.directory || options.root;
+    this.pkgId = options.pkgId;
     this.visited = options.visited || {};
     this.nonExistent = options.nonExistent || [];
     this.isListForm = options.isListForm;
+    this.isPackageForm = options.isPackageForm;
     this.requireConfig = options.config || options.requireConfig;
     this.webpackConfig = options.webpackConfig;
     this.nodeModulesConfig = options.nodeModulesConfig;
@@ -20,6 +22,7 @@ class Config {
 
     if (!this.filename) { throw new Error('filename not given'); }
     if (!this.directory) { throw new Error('directory not given'); }
+    // if (!this.pkgId) { throw new Error('package ID not given'); }
     if (this.filter && typeof this.filter !== 'function') { throw new Error('filter must be a function'); }
 
     if ('string' === typeof this.tsConfig) {
@@ -38,7 +41,7 @@ class Config {
     debug('visited: ', this.visited);
   }
 
-  clone () {
+  clone() {
     return new Config(this);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -942,19 +942,22 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
       "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "array-from": {
       "version": "2.1.1",
@@ -981,7 +984,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "arrify": {
       "version": "1.0.1",
@@ -993,7 +997,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ast-module-types": {
       "version": "2.4.0",
@@ -1017,7 +1022,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1089,6 +1095,7 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -1104,6 +1111,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -1113,6 +1121,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1122,6 +1131,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1131,6 +1141,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1160,6 +1171,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
       "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-flatten": "^1.1.0",
         "array-unique": "^0.3.2",
@@ -1178,6 +1190,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -1212,6 +1225,7 @@
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -1295,6 +1309,7 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -1307,6 +1322,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -1348,6 +1364,7 @@
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -1396,7 +1413,8 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1428,7 +1446,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "core-js": {
       "version": "2.5.7",
@@ -1505,7 +1524,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "decomment": {
       "version": "0.9.2",
@@ -1531,6 +1551,7 @@
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -1541,6 +1562,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1550,6 +1572,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -1559,6 +1582,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -1975,6 +1999,7 @@
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -1990,6 +2015,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1999,6 +2025,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -2008,6 +2035,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2019,6 +2047,7 @@
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -2029,6 +2058,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -2051,6 +2081,7 @@
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -2067,6 +2098,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -2076,6 +2108,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2085,6 +2118,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2094,6 +2128,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -2103,6 +2138,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -2193,6 +2229,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
       "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-number": "^3.0.0",
@@ -2205,6 +2242,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -2260,13 +2298,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -2302,7 +2342,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2323,12 +2364,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2343,17 +2386,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2470,7 +2516,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2482,6 +2529,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2496,6 +2544,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2503,12 +2552,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2527,6 +2578,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2607,7 +2659,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2619,6 +2672,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2704,7 +2758,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2740,6 +2795,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2759,6 +2815,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2802,12 +2859,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2835,7 +2894,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "glob": {
       "version": "7.1.3",
@@ -2952,6 +3012,7 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -2963,6 +3024,7 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -2973,6 +3035,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3135,6 +3198,7 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -3144,6 +3208,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3164,13 +3229,15 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -3180,6 +3247,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3191,6 +3259,7 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -3201,7 +3270,8 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3209,7 +3279,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -3237,6 +3308,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -3246,6 +3318,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -3292,6 +3365,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
+      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -3333,7 +3407,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isarray": {
       "version": "1.0.0",
@@ -3350,7 +3425,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -3572,7 +3648,8 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "levn": {
       "version": "0.3.0",
@@ -3655,13 +3732,15 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
+      "optional": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -3680,6 +3759,7 @@
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
       "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -3720,6 +3800,7 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -3730,6 +3811,7 @@
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -3871,6 +3953,7 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -4013,6 +4096,7 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -4028,6 +4112,7 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
+      "optional": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -4039,6 +4124,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -4048,6 +4134,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4059,6 +4146,7 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
+      "optional": true,
       "requires": {
         "isobject": "^3.0.0"
       }
@@ -4068,6 +4156,7 @@
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
+      "optional": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -4147,7 +4236,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -4256,7 +4346,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "postcss": {
       "version": "7.0.23",
@@ -4460,6 +4551,7 @@
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -4512,19 +4604,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-element": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
       "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "require-uncached": {
       "version": "1.0.3",
@@ -4602,7 +4697,8 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -4618,7 +4714,8 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "revalidator": {
       "version": "0.1.8",
@@ -4678,6 +4775,7 @@
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -4713,6 +4811,7 @@
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -4725,6 +4824,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -4789,6 +4889,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -4805,6 +4906,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -4814,6 +4916,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -4823,6 +4926,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -4831,7 +4935,8 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4840,6 +4945,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -4851,6 +4957,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -4860,6 +4967,7 @@
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -4869,6 +4977,7 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -4878,6 +4987,7 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -4891,6 +5001,7 @@
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.2.0"
       },
@@ -4900,6 +5011,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4916,6 +5028,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -4938,13 +5051,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -4966,6 +5081,7 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -4976,6 +5092,7 @@
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -5126,6 +5243,7 @@
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
       },
@@ -5135,6 +5253,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5146,6 +5265,7 @@
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -5158,6 +5278,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -5257,6 +5378,7 @@
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
+      "optional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -5269,6 +5391,7 @@
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -5278,6 +5401,7 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
           "dev": true,
+          "optional": true,
           "requires": {
             "extend-shallow": "^2.0.1",
             "is-extendable": "^0.1.1",
@@ -5297,6 +5421,7 @@
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -5307,6 +5432,7 @@
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -5318,6 +5444,7 @@
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -5328,7 +5455,8 @@
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5343,13 +5471,15 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/test/test.js
+++ b/test/test.js
@@ -8,14 +8,14 @@ import Config from '../lib/Config';
 
 const dependencyTree = rewire('../');
 
-describe('dependencyTree', function() {
+describe('dependencyTree', function () {
   this.timeout(8000);
   function testTreesForFormat(format, ext = '.js') {
-    it('returns an object form of the dependency tree for a file', function() {
+    it('returns an object form of the dependency tree for a file', function () {
       const root = `${__dirname}/example/${format}`;
       const filename = `${root}/a${ext}`;
 
-      const tree = dependencyTree({filename, root});
+      const tree = dependencyTree({ filename, root });
 
       assert(tree instanceof Object);
 
@@ -83,28 +83,28 @@ describe('dependencyTree', function() {
     });
   }
 
-  afterEach(function() {
+  afterEach(function () {
     mockfs.restore();
   });
 
-  it('returns an empty object for a non-existent filename', function() {
+  it('returns an empty object for a non-existent filename', function () {
     mockfs({
       imaginary: {}
     });
 
     const root = __dirname + '/imaginary';
     const filename = root + '/notafile.js';
-    const tree = dependencyTree({filename, root});
+    const tree = dependencyTree({ filename, root });
 
     assert(tree instanceof Object);
     assert(!Object.keys(tree).length);
   });
 
-  it('handles nested tree structures', function() {
+  it('handles nested tree structures', function () {
     const directory = __dirname + '/example/extended';
     const filename = directory + '/a.js';
 
-    const tree = dependencyTree({filename, directory});
+    const tree = dependencyTree({ filename, directory });
     assert(tree[filename] instanceof Object);
 
     // b and c
@@ -119,7 +119,7 @@ describe('dependencyTree', function() {
     assert.equal(Object.keys(cTree).length, 2);
   });
 
-  it('does not include files that are not real (#13)', function() {
+  it('does not include files that are not real (#13)', function () {
     mockfs({
       [__dirname + '/onlyRealDeps']: {
         'a.js': 'var notReal = require("./notReal");'
@@ -129,13 +129,13 @@ describe('dependencyTree', function() {
     const directory = __dirname + '/onlyRealDeps';
     const filename = directory + '/a.js';
 
-    const tree = dependencyTree({filename, directory});
+    const tree = dependencyTree({ filename, directory });
     const subTree = tree[filename];
 
     assert.ok(!Object.keys(subTree).some(dep => dep.indexOf('notReal') !== -1));
   });
 
-  it('does not choke on cyclic dependencies', function() {
+  it('does not choke on cyclic dependencies', function () {
     mockfs({
       [__dirname + '/cyclic']: {
         'a.js': 'var b = require("./b");',
@@ -148,7 +148,7 @@ describe('dependencyTree', function() {
 
     const spy = sinon.spy(dependencyTree, '_getDependencies');
 
-    const tree = dependencyTree({filename, directory});
+    const tree = dependencyTree({ filename, directory });
 
     assert(spy.callCount === 2);
     assert(Object.keys(tree[filename]).length);
@@ -156,37 +156,37 @@ describe('dependencyTree', function() {
     dependencyTree._getDependencies.restore();
   });
 
-  it('excludes Nodejs core modules by default', function() {
+  it('excludes Nodejs core modules by default', function () {
     const directory = __dirname + '/example/commonjs';
     const filename = directory + '/b.js';
 
-    const tree = dependencyTree({filename, directory});
+    const tree = dependencyTree({ filename, directory });
     assert(Object.keys(tree[filename]).length === 0);
     assert(Object.keys(tree)[0].indexOf('b.js') !== -1);
   });
 
-  it('traverses installed 3rd party node modules', function() {
+  it('traverses installed 3rd party node modules', function () {
     const directory = __dirname + '/example/onlyRealDeps';
     const filename = directory + '/a.js';
 
-    const tree = dependencyTree({filename, directory});
+    const tree = dependencyTree({ filename, directory });
     const subTree = tree[filename];
 
     assert(Object.keys(subTree).some(dep => dep === require.resolve('debug')));
   });
 
-  it('returns a list of absolutely pathed files', function() {
+  it('returns a list of absolutely pathed files', function () {
     const directory = __dirname + '/example/commonjs';
     const filename = directory + '/b.js';
 
-    const tree = dependencyTree({filename, directory});
+    const tree = dependencyTree({ filename, directory });
 
     for (let node in tree.nodes) {
       assert(node.indexOf(process.cwd()) !== -1);
     }
   });
 
-  it('excludes duplicate modules from the tree', function() {
+  it('excludes duplicate modules from the tree', function () {
     mockfs({
       root: {
         // More than one module includes c
@@ -205,8 +205,8 @@ describe('dependencyTree', function() {
     assert(tree.length === 3);
   });
 
-  describe('when given a detective configuration', function() {
-    it('passes it through to precinct', function() {
+  describe('when given a detective configuration', function () {
+    it('passes it through to precinct', function () {
       const spy = sinon.spy(precinct, 'paperwork');
       const directory = __dirname + '/example/onlyRealDeps';
       const filename = directory + '/a.js';
@@ -227,9 +227,9 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('when given a list to store non existent partials', function() {
-    describe('and the file contains no valid partials', function() {
-      it('stores the invalid partials', function() {
+  describe('when given a list to store non existent partials', function () {
+    describe('and the file contains no valid partials', function () {
+      it('stores the invalid partials', function () {
         mockfs({
           [__dirname + '/onlyRealDeps']: {
             'a.js': 'var notReal = require("./notReal");'
@@ -240,15 +240,15 @@ describe('dependencyTree', function() {
         const filename = directory + '/a.js';
         const nonExistent = [];
 
-        const tree = dependencyTree({filename, directory, nonExistent});
+        const tree = dependencyTree({ filename, directory, nonExistent });
 
         assert.equal(nonExistent.length, 1);
         assert.equal(nonExistent[0], './notReal');
       });
     });
 
-    describe('and the file contains all valid partials', function() {
-      it('does not store anything', function() {
+    describe('and the file contains all valid partials', function () {
+      it('does not store anything', function () {
         mockfs({
           [__dirname + '/onlyRealDeps']: {
             'a.js': 'var b = require("./b");',
@@ -260,14 +260,14 @@ describe('dependencyTree', function() {
         const filename = directory + '/a.js';
         const nonExistent = [];
 
-        const tree = dependencyTree({filename, directory, nonExistent});
+        const tree = dependencyTree({ filename, directory, nonExistent });
 
         assert.equal(nonExistent.length, 0);
       });
     });
 
-    describe('and the file contains a mix of invalid and valid partials', function() {
-      it('stores the invalid ones', function() {
+    describe('and the file contains a mix of invalid and valid partials', function () {
+      it('stores the invalid ones', function () {
         mockfs({
           [__dirname + '/onlyRealDeps']: {
             'a.js': 'var b = require("./b");',
@@ -280,15 +280,15 @@ describe('dependencyTree', function() {
         const filename = directory + '/a.js';
         const nonExistent = [];
 
-        const tree = dependencyTree({filename, directory, nonExistent});
+        const tree = dependencyTree({ filename, directory, nonExistent });
 
         assert.equal(nonExistent.length, 1);
         assert.equal(nonExistent[0], './notRealMan');
       });
     });
 
-    describe('and there is more than one reference to the invalid partial', function() {
-      it('only includes the non-existent partial once', function() {
+    describe('and there is more than one reference to the invalid partial', function () {
+      it('only includes the non-existent partial once', function () {
         mockfs({
           [__dirname + '/onlyRealDeps']: {
             'a.js': 'var b = require("./b");\nvar crap = require("./notRealMan");',
@@ -301,7 +301,7 @@ describe('dependencyTree', function() {
         const filename = directory + '/a.js';
         const nonExistent = [];
 
-        const tree = dependencyTree({filename, directory, nonExistent});
+        const tree = dependencyTree({ filename, directory, nonExistent });
 
         assert.equal(nonExistent.length, 1);
         assert.equal(nonExistent[0], './notRealMan');
@@ -309,18 +309,18 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('throws', function() {
-    beforeEach(function() {
+  describe('throws', function () {
+    beforeEach(function () {
       this._directory = __dirname + '/example/commonjs';
       this._revert = dependencyTree.__set__('traverse', () => []);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       this._revert();
     });
 
-    it('throws if the filename is missing', function() {
-      assert.throws(function() {
+    it('throws if the filename is missing', function () {
+      assert.throws(function () {
         dependencyTree({
           filename: undefined,
           directory: this._directory
@@ -328,14 +328,14 @@ describe('dependencyTree', function() {
       });
     });
 
-    it('throws if the root is missing', function() {
-      assert.throws(function() {
-        dependencyTree({filename});
+    it('throws if the root is missing', function () {
+      assert.throws(function () {
+        dependencyTree({ filename });
       });
     });
 
-    it('throws if a supplied filter is not a function', function() {
-      assert.throws(function() {
+    it('throws if a supplied filter is not a function', function () {
+      assert.throws(function () {
         const directory = __dirname + '/example/onlyRealDeps';
         const filename = directory + '/a.js';
 
@@ -347,8 +347,8 @@ describe('dependencyTree', function() {
       });
     });
 
-    it('does not throw on the legacy `root` option', function() {
-      assert.doesNotThrow(function() {
+    it('does not throw on the legacy `root` option', function () {
+      assert.doesNotThrow(function () {
         const directory = __dirname + '/example/onlyRealDeps';
         const filename = directory + '/a.js';
 
@@ -360,12 +360,12 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('on file error', function() {
-    beforeEach(function() {
+  describe('on file error', function () {
+    beforeEach(function () {
       this._directory = __dirname + '/example/commonjs';
     });
 
-    it('does not throw', function() {
+    it('does not throw', function () {
       assert.doesNotThrow(() => {
         dependencyTree({
           filename: 'foo',
@@ -374,14 +374,14 @@ describe('dependencyTree', function() {
       });
     });
 
-    it('returns no dependencies', function() {
-      const tree = dependencyTree({filename: 'foo', directory: this._directory});
+    it('returns no dependencies', function () {
+      const tree = dependencyTree({ filename: 'foo', directory: this._directory });
       assert(!tree.length);
     });
   });
 
-  describe('when a filter function is supplied', function() {
-    it('uses the filter to determine if a file should be included in the results', function() {
+  describe('when a filter function is supplied', function () {
+    it('uses the filter to determine if a file should be included in the results', function () {
       const directory = __dirname + '/example/onlyRealDeps';
       const filename = directory + '/a.js';
 
@@ -404,16 +404,16 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('memoization (#2)', function() {
-    beforeEach(function() {
+  describe('memoization (#2)', function () {
+    beforeEach(function () {
       this._spy = sinon.spy(dependencyTree, '_getDependencies');
     });
 
-    afterEach(function() {
+    afterEach(function () {
       dependencyTree._getDependencies.restore();
     });
 
-    it('accepts a cache object for memoization (#2)', function() {
+    it('accepts a cache object for memoization (#2)', function () {
       const filename = __dirname + '/example/amd/a.js';
       const directory = __dirname + '/example/amd';
       const cache = {};
@@ -433,7 +433,7 @@ describe('dependencyTree', function() {
       assert(this._spy.neverCalledWith(__dirname + '/example/amd/b.js'));
     });
 
-    it('returns the precomputed list of a cached entry point', function() {
+    it('returns the precomputed list of a cached entry point', function () {
       const filename = __dirname + '/example/amd/a.js';
       const directory = __dirname + '/example/amd';
 
@@ -452,16 +452,16 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('module formats', function() {
-    describe('amd', function() {
+  describe('module formats', function () {
+    describe('amd', function () {
       testTreesForFormat('amd');
     });
 
-    describe('commonjs', function() {
+    describe('commonjs', function () {
       testTreesForFormat('commonjs');
 
-      describe('when given a CJS file with lazy requires', function() {
-        beforeEach(function() {
+      describe('when given a CJS file with lazy requires', function () {
+        beforeEach(function () {
           mockfs({
             [__dirname + '/cjs']: {
               'foo.js': 'module.exports = function(bar = require("./bar")) {};',
@@ -470,19 +470,19 @@ describe('dependencyTree', function() {
           });
         });
 
-        it('includes the lazy dependency', function() {
+        it('includes the lazy dependency', function () {
           const directory = __dirname + '/cjs';
           const filename = directory + '/foo.js';
 
-          const tree = dependencyTree({filename, directory});
+          const tree = dependencyTree({ filename, directory });
           const subTree = tree[filename];
 
           assert.ok(`${directory}/bar.js` in subTree);
         });
       });
 
-      describe('when given a CJS file with module property in package.json', function() {
-        beforeEach(function() {
+      describe('when given a CJS file with module property in package.json', function () {
+        beforeEach(function () {
           mockfs({
             [__dirname + '/es6']: {
               ['module.entry.js']: 'import * as module from "module.entry"',
@@ -497,7 +497,7 @@ describe('dependencyTree', function() {
           });
         });
 
-        it('it includes the module entry as dependency', function() {
+        it('it includes the module entry as dependency', function () {
           const directory = __dirname + '/es6';
           const filename = directory + '/module.entry.js';
 
@@ -515,17 +515,17 @@ describe('dependencyTree', function() {
       });
     });
 
-    describe('es6', function() {
-      beforeEach(function() {
+    describe('es6', function () {
+      beforeEach(function () {
         this._directory = __dirname + '/example/es6';
         mockes6();
       });
 
       testTreesForFormat('es6');
 
-      it('resolves files that have jsx', function() {
+      it('resolves files that have jsx', function () {
         const filename = `${this._directory}/jsx.js`;
-        const {[filename]: tree} = dependencyTree({
+        const { [filename]: tree } = dependencyTree({
           filename,
           directory: this._directory
         });
@@ -533,9 +533,9 @@ describe('dependencyTree', function() {
         assert.ok(tree[`${this._directory}/c.js`]);
       });
 
-      it('resolves files with a jsx extension', function() {
+      it('resolves files with a jsx extension', function () {
         const filename = `${this._directory}/foo.jsx`;
-        const {[filename]: tree} = dependencyTree({
+        const { [filename]: tree } = dependencyTree({
           filename,
           directory: this._directory
         });
@@ -543,9 +543,9 @@ describe('dependencyTree', function() {
         assert.ok(tree[`${this._directory}/b.js`]);
       });
 
-      it('resolves files that have es7', function() {
+      it('resolves files that have es7', function () {
         const filename = `${this._directory}/es7.js`;
-        const {[filename]: tree} = dependencyTree({
+        const { [filename]: tree } = dependencyTree({
           filename,
           directory: this._directory
         });
@@ -553,8 +553,8 @@ describe('dependencyTree', function() {
         assert.ok(tree[`${this._directory}/c.js`]);
       });
 
-      describe('when given an es6 file using CJS lazy requires', function() {
-        beforeEach(function() {
+      describe('when given an es6 file using CJS lazy requires', function () {
+        beforeEach(function () {
           mockfs({
             [__dirname + '/es6']: {
               'foo.js': 'export default function(bar = require("./bar")) {};',
@@ -563,8 +563,8 @@ describe('dependencyTree', function() {
           });
         });
 
-        describe('and mixedImport mode is turned on', function() {
-          it('includes the lazy dependency', function() {
+        describe('and mixedImport mode is turned on', function () {
+          it('includes the lazy dependency', function () {
             const directory = __dirname + '/es6';
             const filename = directory + '/foo.js';
 
@@ -583,7 +583,7 @@ describe('dependencyTree', function() {
             assert.ok(`${directory}/bar.js` in subTree);
           });
 
-          it('also works for toList', function() {
+          it('also works for toList', function () {
             const directory = __dirname + '/es6';
             const filename = directory + '/foo.js';
 
@@ -602,8 +602,8 @@ describe('dependencyTree', function() {
           });
         });
 
-        describe('and mixedImport mode is turned off', function() {
-          it('does not include the lazy dependency', function() {
+        describe('and mixedImport mode is turned off', function () {
+          it('does not include the lazy dependency', function () {
             const directory = __dirname + '/es6';
             const filename = directory + '/foo.js';
 
@@ -619,8 +619,8 @@ describe('dependencyTree', function() {
         });
       });
 
-      describe('when given an es6 file using dynamic imports', function() {
-        beforeEach(function() {
+      describe('when given an es6 file using dynamic imports', function () {
+        beforeEach(function () {
           mockfs({
             [__dirname + '/es6']: {
               'foo.js': 'import("./bar");',
@@ -629,7 +629,7 @@ describe('dependencyTree', function() {
           });
         });
 
-        it('includes the dynamic import', function() {
+        it('includes the dynamic import', function () {
           const directory = __dirname + '/es6';
           const filename = directory + '/foo.js';
 
@@ -645,34 +645,34 @@ describe('dependencyTree', function() {
       });
     });
 
-    describe('sass', function() {
-      beforeEach(function() {
+    describe('sass', function () {
+      beforeEach(function () {
         mockSass();
       });
 
       testTreesForFormat('sass', '.scss');
     });
 
-    describe('stylus', function() {
-      beforeEach(function() {
+    describe('stylus', function () {
+      beforeEach(function () {
         mockStylus();
       });
 
       testTreesForFormat('stylus', '.styl');
     });
 
-    describe('less', function() {
-      beforeEach(function() {
+    describe('less', function () {
+      beforeEach(function () {
         mockLess();
       });
 
       testTreesForFormat('less', '.less');
     });
 
-    describe('typescript', function() {
+    describe('typescript', function () {
       testTreesForFormat('ts', '.ts');
 
-      it('utilizes a tsconfig', function() {
+      it('utilizes a tsconfig', function () {
         const directory = path.join(__dirname, 'example/ts');
         const tsConfigPath = path.join(directory, '.tsconfig');
 
@@ -687,7 +687,7 @@ describe('dependencyTree', function() {
         assert.equal(results[2], path.join(directory, 'a.ts'));
       });
 
-      it('supports tsx files', function() {
+      it('supports tsx files', function () {
         const directory = path.join(__dirname, 'example/ts');
 
         const results = dependencyTree.toList({
@@ -700,9 +700,9 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('toList', function() {
+  describe('toList', function () {
     function testToList(format, ext = '.js') {
-      it('returns a post-order list form of the dependency tree', function() {
+      it('returns a post-order list form of the dependency tree', function () {
         const directory = __dirname + '/example/' + format;
         const filename = directory + '/a' + ext;
 
@@ -716,7 +716,7 @@ describe('dependencyTree', function() {
       });
     }
 
-    it('returns an empty list on a non-existent filename', function() {
+    it('returns an empty list on a non-existent filename', function () {
       mockfs({
         imaginary: {}
       });
@@ -733,7 +733,7 @@ describe('dependencyTree', function() {
       assert(!list.length);
     });
 
-    it('orders the visited files by last visited', function() {
+    it('orders the visited files by last visited', function () {
       const directory = __dirname + '/example/amd';
       const filename = directory + '/a.js';
       const list = dependencyTree.toList({
@@ -747,55 +747,55 @@ describe('dependencyTree', function() {
       assert(list[list.length - 1] === filename);
     });
 
-    describe('module formats', function() {
-      describe('amd', function() {
+    describe('module formats', function () {
+      describe('amd', function () {
         testToList('amd');
       });
 
-      describe('commonjs', function() {
+      describe('commonjs', function () {
         testToList('commonjs');
       });
 
-      describe('es6', function() {
-        beforeEach(function() {
+      describe('es6', function () {
+        beforeEach(function () {
           mockes6();
         });
 
         testToList('es6');
       });
 
-      describe('sass', function() {
-        beforeEach(function() {
+      describe('sass', function () {
+        beforeEach(function () {
           mockSass();
         });
 
         testToList('sass', '.scss');
       });
 
-      describe('stylus', function() {
-        beforeEach(function() {
+      describe('stylus', function () {
+        beforeEach(function () {
           mockStylus();
         });
 
         testToList('stylus', '.styl');
       });
 
-      describe('less', function() {
-        beforeEach(function() {
+      describe('less', function () {
+        beforeEach(function () {
           mockLess();
         });
 
         testToList('less', '.less');
       });
 
-      describe('typescript', function() {
+      describe('typescript', function () {
         testToList('ts', '.ts');
       });
     });
   });
 
-  describe('webpack', function() {
-    beforeEach(function() {
+  describe('webpack', function () {
+    beforeEach(function () {
       // Note: not mocking because webpack's resolver needs a real project with dependencies;
       // otherwise, we'd have to mock a ton of files.
       this._root = path.join(__dirname, '../');
@@ -813,19 +813,19 @@ describe('dependencyTree', function() {
       };
     });
 
-    it('resolves aliased modules', function() {
+    it('resolves aliased modules', function () {
       this.timeout(5000);
       this._testResolution('aliased');
     });
 
-    it('resolves unaliased modules', function() {
+    it('resolves unaliased modules', function () {
       this.timeout(5000);
       this._testResolution('unaliased');
     });
   });
 
-  describe('requirejs', function() {
-    beforeEach(function() {
+  describe('requirejs', function () {
+    beforeEach(function () {
       mockfs({
         root: {
           'lodizzle.js': 'define({})',
@@ -855,7 +855,7 @@ describe('dependencyTree', function() {
       });
     });
 
-    it('resolves aliased modules', function() {
+    it('resolves aliased modules', function () {
       const tree = dependencyTree({
         filename: 'root/a.js',
         directory: 'root',
@@ -867,7 +867,7 @@ describe('dependencyTree', function() {
       assert.ok('root/lodizzle.js' in tree[filename]);
     });
 
-    it('resolves non-aliased paths', function() {
+    it('resolves non-aliased paths', function () {
       const tree = dependencyTree({
         filename: 'root/b.js',
         directory: 'root',
@@ -880,9 +880,9 @@ describe('dependencyTree', function() {
     });
   });
 
-  describe('Config', function() {
-    describe('when given a path to a typescript config', function() {
-      it('pre-parses the config for performance', function() {
+  describe('Config', function () {
+    describe('when given a path to a typescript config', function () {
+      it('pre-parses the config for performance', function () {
         const directory = path.join(__dirname, 'example/ts');
         const tsConfigPath = path.join(directory, '.tsconfig');
         const config = new Config({
@@ -895,9 +895,9 @@ describe('dependencyTree', function() {
       });
     });
 
-    describe('when cloning', function() {
-      describe('and a detective config was set', function() {
-        it('retains the detective config in the clone', function() {
+    describe('when cloning', function () {
+      describe('and a detective config was set', function () {
+        it('retains the detective config in the clone', function () {
           const detectiveConfig = {
             es6: {
               mixedImports: true


### PR DESCRIPTION
Hi, there! I'm using this module to do some npm dependency analysis, and I really want to get the dependencies' package names and versions, so I've made some changes to suit my needs. I found that the information I needed was stored in the value of `"_id"` entry in `package.json` file in `node_modules` folder (`./node_modules/dependency-folder/package.json` of a node project, in format `package-name@semantic-version`). So I wrote a function `getPacakgeId` to get that as a string and modified the `traverse` function to construct an array of the results.

One thing that I think might be uncool is that there are many changes to spacing especially after function names, and this is in fact Visual Studio Code's conduct (or maybe the extension Prettier's). Sorry, I hope you're cool with that.