### PR TITLE
allow "noTypeDefinitions" flag to pass through to filing-cabinet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ var tree = dependencyTree({
     entry: 'module'
   }, // optional
   filter: path => path.indexOf('node_modules') === -1, // optional
-  nonExistent: [] // optional
+  nonExistent: [], // optional
+  noTypeDefinitions: false // optional
 });
 
 // Returns a post-order traversal (list form) of the tree with duplicate sub-trees pruned.
@@ -51,6 +52,7 @@ var list = dependencyTree.toList({
 * `detective`: object with configuration specific to detectives used to find dependencies of a file
   - for example `detective.amd.skipLazyLoaded: true` tells the AMD detective to omit inner requires
   - See [precinct's usage docs](https://github.com/dependents/node-precinct#usage) for the list of module types you can pass options to.
+* `noTypeDefinitions`: if truthy, prefer `.js` files over `.d.ts` files
 
 #### Format Details
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const Config = require('./lib/Config');
  * @param {Object} [options.visited] - Cache of visited, absolutely pathed files that should not be reprocessed.
  *                             Format is a filename -> tree as list lookup table
  * @param {Array} [options.nonExistent] - List of partials that do not exist
+ * @param {Boolean} [options.noTypeDefinitions=false] - For typescript files, whether to prefer *.js over *.d.ts
  * @param {Boolean} [options.isListForm=false]
  * @param {String|Object} [options.tsConfig] Path to a typescript config (or a preloaded one).
  * @return {Object}
@@ -109,7 +110,8 @@ module.exports._getDependencies = function(config) {
       config: config.requireConfig,
       webpackConfig: config.webpackConfig,
       nodeModulesConfig: config.nodeModulesConfig,
-      tsConfig: config.tsConfig
+      tsConfig: config.tsConfig,
+      noTypeDefinitions: config.noTypeDefinitions
     });
 
     if (!result) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -15,7 +15,7 @@ class Config {
     this.nodeModulesConfig = options.nodeModulesConfig;
     this.detectiveConfig = options.detective || options.detectiveConfig || {};
     this.tsConfig = options.tsConfig;
-
+    this.noTypeDefinitions = options.noTypeDefinitions;
     this.filter = options.filter;
 
     if (!this.filename) { throw new Error('filename not given'); }

--- a/test/example/ts/noTypeDefinitions/.tsconfig
+++ b/test/example/ts/noTypeDefinitions/.tsconfig
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true
+  }
+}

--- a/test/example/ts/noTypeDefinitions/a.ts
+++ b/test/example/ts/noTypeDefinitions/a.ts
@@ -1,0 +1,2 @@
+import b from './b';
+import c from './c';

--- a/test/example/ts/noTypeDefinitions/b.d.ts
+++ b/test/example/ts/noTypeDefinitions/b.d.ts
@@ -1,0 +1,1 @@
+export default function (): void;

--- a/test/example/ts/noTypeDefinitions/b.js
+++ b/test/example/ts/noTypeDefinitions/b.js
@@ -1,0 +1,5 @@
+"use strict";
+exports.__esModule = true;
+function default_1() { }
+exports["default"] = default_1;
+;

--- a/test/example/ts/noTypeDefinitions/c.d.ts
+++ b/test/example/ts/noTypeDefinitions/c.d.ts
@@ -1,0 +1,1 @@
+export default function (): void;

--- a/test/example/ts/noTypeDefinitions/c.js
+++ b/test/example/ts/noTypeDefinitions/c.js
@@ -1,0 +1,5 @@
+"use strict";
+exports.__esModule = true;
+function default_1() { }
+exports["default"] = default_1;
+;

--- a/test/test.js
+++ b/test/test.js
@@ -720,6 +720,24 @@ describe('dependencyTree', function() {
 
         assert.equal(results[0], path.join(directory, 'b.ts'));
       });
+
+      it('respects "noTypeDefinitions" flag', function() {
+        const directory = path.join(__dirname, 'example/ts/noTypeDefinitions');
+        const tsConfigPath = path.join(directory, '.tsconfig');
+
+        const results = dependencyTree.toList({
+          filename: `${directory}/a.ts`,
+          directory,
+          tsConfig: tsConfigPath,
+          noTypeDefinitions: true
+        });
+
+        assert.deepStrictEqual(results, [
+          path.join(directory, 'b.js'),
+          path.join(directory, 'c.js'),
+          path.join(directory, 'a.ts')
+        ]);
+      })
     });
   });
 


### PR DESCRIPTION
This adds support for filing-cabinet's `noTypeDefinitions` flag to `dependency-tree`

- added tests / fixtures
- updated `README.md`

there are problems running the test suite on newer versions of Node.js, but I didn't bother with it.  will be surprised if Travis-CI even runs this