### PR TITLE
feat: add noTypeDefinitions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ var tree = dependencyTree({
     entry: 'module'
   }, // optional
   filter: path => path.indexOf('node_modules') === -1, // optional
-  nonExistent: [] // optional
+  nonExistent: [], // optional
+  noTypeDefinitions: false // optional
 });
 
 // Returns a post-order traversal (list form) of the tree with duplicate sub-trees pruned.
@@ -51,6 +52,7 @@ var list = dependencyTree.toList({
 * `detective`: object with configuration specific to detectives used to find dependencies of a file
   - for example `detective.amd.skipLazyLoaded: true` tells the AMD detective to omit inner requires
   - See [precinct's usage docs](https://github.com/dependents/node-precinct#usage) for the list of module types you can pass options to.
+* `noTypeDefinitions`: For TypeScript imports, whether to resolve to `*.js` instead of `*.d.ts`.
 
 #### Format Details
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,32 @@
+declare namespace dependencyTree {
+  interface TreeInnerNode {
+    [parent: string]: TreeInnerNode | string;
+  }
+  type Tree = TreeInnerNode | string;
+
+  interface Options {
+    filename: string;
+    directory: string;
+    visited?: Tree;
+    nonExistent?: string[];
+    isListForm?: boolean;
+    requireConfig?: string;
+    webpackConfig?: string;
+    nodeModulesConfig?: any;
+    detectiveConfig?: any;
+    tsConfig?: string | Record<string, any>;
+    noTypeDefinitions?: boolean;
+    filter?: (path: string) => boolean;
+  }
+
+  interface Config extends Options {
+    clone: () => Config;
+  }
+
+  function toList (options: Options): string[];
+  function _getDependencies (config: Config): string[];
+}
+
+declare function dependencyTree (options: dependencyTree.Options): dependencyTree.Tree;
+
+export = dependencyTree;

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const Config = require('./lib/Config');
  * @param {Array} [options.nonExistent] - List of partials that do not exist
  * @param {Boolean} [options.isListForm=false]
  * @param {String|Object} [options.tsConfig] Path to a typescript config (or a preloaded one).
+ * @param {Boolean} [options.noTypeDefinitions] For TypeScript imports, whether to resolve to `*.js` instead of `*.d.ts`.
  * @return {Object}
  */
 module.exports = function(options) {

--- a/index.js
+++ b/index.js
@@ -109,7 +109,8 @@ module.exports._getDependencies = function(config) {
       config: config.requireConfig,
       webpackConfig: config.webpackConfig,
       nodeModulesConfig: config.nodeModulesConfig,
-      tsConfig: config.tsConfig
+      tsConfig: config.tsConfig,
+      noTypeDefinitions: config.noTypeDefinitions
     });
 
     if (!result) {

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -15,6 +15,7 @@ class Config {
     this.nodeModulesConfig = options.nodeModulesConfig;
     this.detectiveConfig = options.detective || options.detectiveConfig || {};
     this.tsConfig = options.tsConfig;
+    this.noTypeDefinitions = options.noTypeDefinitions;
 
     this.filter = options.filter;
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "8.0.0",
   "description": "Get the dependency tree of a module",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "jscs index.js test/test.js && ./node_modules/.bin/mocha --require esm test/test.js"
   },

--- a/test/example/noTypeDefinitions/entrypoint.ts
+++ b/test/example/noTypeDefinitions/entrypoint.ts
@@ -1,0 +1,1 @@
+import { theAnswer } from './required';

--- a/test/example/noTypeDefinitions/required.d.ts
+++ b/test/example/noTypeDefinitions/required.d.ts
@@ -1,0 +1,1 @@
+export const theAnswer: number;

--- a/test/example/noTypeDefinitions/required.js
+++ b/test/example/noTypeDefinitions/required.js
@@ -1,0 +1,3 @@
+module.exports = {
+  theAnswer: 42
+};

--- a/test/test.js
+++ b/test/test.js
@@ -205,6 +205,16 @@ describe('dependencyTree', function() {
     assert(tree.length === 3);
   });
 
+  it('resolves TypeScript imports to their type definition files by default', function() {
+    const directory = path.join(__dirname, 'example', 'noTypeDefinitions');
+    const filename = path.join(directory, 'entrypoint.ts');
+
+    const list = dependencyTree.toList({filename, directory});
+
+    assert(list.includes(path.join(directory, 'required.d.ts')));
+    assert(!list.includes(path.join(directory, 'required.js')));
+  });
+
   describe('when given a detective configuration', function() {
     it('passes it through to precinct', function() {
       const spy = sinon.spy(precinct, 'paperwork');
@@ -900,6 +910,32 @@ describe('dependencyTree', function() {
       const filename = path.resolve(process.cwd(), 'root/b.js');
       const aliasedFile = path.resolve(process.cwd(), 'root/lodizzle.js');
       assert.ok('root/lodizzle.js' in tree[filename]);
+    });
+  });
+
+  describe('when noTypeDefinitions is set', function() {
+    describe('and it is set to false', function() {
+      it('resolves TypeScript imports to their definition files', function() {
+        const directory = path.join(__dirname, 'example', 'noTypeDefinitions');
+        const filename = path.join(directory, 'entrypoint.ts');
+
+        const list = dependencyTree.toList({filename, directory, noTypeDefinitions: false});
+
+        assert(list.includes(path.join(directory, 'required.d.ts')));
+        assert(!list.includes(path.join(directory, 'required.js')));
+      });
+    });
+
+    describe('and it is set to true', function() {
+      it('resolves TypeScript imports to their JavaScript implementation files', function() {
+        const directory = path.join(__dirname, 'example', 'noTypeDefinitions');
+        const filename = path.join(directory, 'entrypoint.ts');
+
+        const list = dependencyTree.toList({filename, directory, noTypeDefinitions: true});
+
+        assert(list.includes(path.join(directory, 'required.js')));
+        assert(!list.includes(path.join(directory, 'required.d.ts')));
+      });
     });
   });
 


### PR DESCRIPTION
Hi there :wave: 

first of all: Thank you for this useful project! :smile: 

I use a lot of TypeScript and I've found a small inconvenience when using your project with it. Filing cabinet has two ways of resolving TS imports, the first one - the one that is used by default - resolves these to the type definitions. The other one resolves to the JavaScript implementations instead.

So why should you be able to resolve to the `.js` files and not to the `d.ts` files?
The problem with just resolving to the type definitions is, that definition files don't usually contain imports of all dependencies, so we're missing transitive dependencies here.

Picture this scenario: You're using some dependency A which is written in JS, but provides TS definitions. A uses B as its dependency. When we resolve A to its definition file, that file doesn't include the import for B, so we're missing B in the dependency tree. If we resolve to the JS file instead, this doesn't happen.

So this is what I implemented here. I've add the `noDefinitionFiles` option from filing cabinet to this packages' options. With this option, it is possible to toggle between both behaviors. To keep the code compatible with older versions, the default is the same as before - resolve to definition files.

I've added test cases for this as well. :tada: 

Also, since I want to use this with TypeScript, I've added type definitions to your package. They should be compatible with the [ones provided by DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/dependency-tree/index.d.ts) and reflect the new changes, but feel free to revert this commit if you don't want to add types at this point. All changes related to the addition of types are contained in 149151f, so you're able to discard these more easily. I'd also be happy to create a second PR for the type definitions, if that's how you'd like to handle it.