### PR TITLE
upgrade `typescript`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "debug": "^4.3.1",
         "filing-cabinet": "^3.0.1",
         "precinct": "^9.0.0",
-        "typescript": "^4.0.0"
+        "typescript": "^4.0.0 || ^5.0.0"
       },
       "bin": {
         "dependency-tree": "bin/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "commander": "^2.20.3",
         "debug": "^4.3.1",
         "filing-cabinet": "^3.0.1",
-        "precinct": "^9.0.0",
-        "typescript": "^4.0.0 || ^5.0.0"
+        "precinct": "^10.0.0",
+        "typescript": "^5.0.0"
       },
       "bin": {
         "dependency-tree": "bin/cli.js"
@@ -67,6 +67,29 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@dependents/detective-less": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-3.0.1.tgz",
+      "integrity": "sha512-NjjCPJbx/za2287T6gnC5zD2IFSplro1evaTV9yvx3jnPpHi7s8PwJvh9vvJRFnMx5nbakodwNOnFvk8+9YQTg==",
+      "dependencies": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@dependents/detective-less/node_modules/node-source-walk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
+      "dependencies": {
+        "@babel/parser": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -147,9 +170,9 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.0.tgz",
-      "integrity": "sha512-eslFG0Qy8wpGzDdYKu58CEr3WLkjwC5Usa6XbuV89ce/yN5RITLe1O8e+WFEuxnfftHiJImkkOBADj58ahRxSg==",
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
+      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -159,12 +182,12 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.0.tgz",
-      "integrity": "sha512-LxfKCG4bsRGq60Sqqu+34QT5qT2TEAHvSCCJ321uBWywgE2dS0LKcu5u+3sMGo+Vy9UmLOhdTw5JHzePV/1y4Q==",
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
+      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
       "dependencies": {
-        "@typescript-eslint/types": "5.47.0",
-        "@typescript-eslint/visitor-keys": "5.47.0",
+        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/visitor-keys": "5.58.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -184,37 +207,10 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -226,11 +222,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.0.tgz",
-      "integrity": "sha512-ByPi5iMa6QqDXe/GmT/hR6MZtVPi0SqMQPDx15FczCBXJo/7M8T88xReOALAfpBLm+zxpPfmhuEvPb577JRAEg==",
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
+      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
       "dependencies": {
-        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/types": "5.58.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -242,11 +238,14 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -524,42 +523,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar/node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/chokidar/node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -572,15 +535,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/chokidar/node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
     "node_modules/chokidar/node_modules/readdirp": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -591,18 +545,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/chokidar/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
       }
     },
     "node_modules/cli-cursor": {
@@ -808,9 +750,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -861,14 +803,14 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "node_modules/detective-amd": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-4.0.1.tgz",
-      "integrity": "sha512-bDo22IYbJ8yzALB0Ow5CQLtyhU1BpDksLB9dsWHI9Eh0N3OQR6aQqhjPsNDd69ncYwRfL1sTo7OA9T3VRVSe2Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-4.1.0.tgz",
+      "integrity": "sha512-XlQrGjGEnMFjKbep0/S/T7XICxf25LFMP6Ug+Iw/Ww/MHUBzfy8QETCzamO1JlAMYPmkChDh21/NS/csG0FwGg==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
+        "ast-module-types": "^4.0.0",
         "escodegen": "^2.0.0",
-        "get-amd-module-type": "^4.0.0",
-        "node-source-walk": "^5.0.0"
+        "get-amd-module-type": "^4.1.0",
+        "node-source-walk": "^5.0.1"
       },
       "bin": {
         "detective-amd": "bin/cli.js"
@@ -878,17 +820,17 @@
       }
     },
     "node_modules/detective-amd/node_modules/ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+      "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/detective-amd/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -897,29 +839,29 @@
       }
     },
     "node_modules/detective-cjs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-4.0.0.tgz",
-      "integrity": "sha512-VsD6Yo1+1xgxJWoeDRyut7eqZ8EWaJI70C5eanSAPcBHzenHZx0uhjxaaEfIm0cHII7dBiwU98Orh44bwXN2jg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-4.1.0.tgz",
+      "integrity": "sha512-QxzMwt5MfPLwS7mG30zvnmOvHLx5vyVvjsAV6gQOyuMoBR5G1DhS1eJZ4P10AlH+HSnk93mTcrg3l39+24XCtg==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0"
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/detective-cjs/node_modules/ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+      "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/detective-cjs/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -928,9 +870,9 @@
       }
     },
     "node_modules/detective-es6": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-3.0.0.tgz",
-      "integrity": "sha512-Uv2b5Uih7vorYlqGzCX+nTPUb4CMzUAn3VPHTV5p5lBkAN4cAApLGgUz4mZE2sXlBfv4/LMmeP7qzxHV/ZcfWA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-3.0.1.tgz",
+      "integrity": "sha512-evPeYIEdK1jK3Oji5p0hX4sPV/1vK+o4ihcWZkMQE6voypSW/cIBiynOLxQk5KOOQbdP8oOAsYqouMTYO5l1sw==",
       "dependencies": {
         "node-source-walk": "^5.0.0"
       },
@@ -939,9 +881,9 @@
       }
     },
     "node_modules/detective-es6/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -949,26 +891,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/detective-less": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.2.tgz",
-      "integrity": "sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==",
-      "dependencies": {
-        "debug": "^4.0.0",
-        "gonzales-pe": "^4.2.3",
-        "node-source-walk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 6.0"
-      }
-    },
     "node_modules/detective-postcss": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.0.tgz",
-      "integrity": "sha512-ZFZnEmUrL2XHAC0j/4D1fdwZbo/anAcK84soJh7qc7xfx2Kc8gFO5Bk5I9jU7NLC/OAF1Yho1GLxEDnmQnRH2A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.1.tgz",
+      "integrity": "sha512-mX62A6chiafyFW9AwGF6B/uVU+F3hGMZwXDqCHe+NjmU/M5jlDBazdXb1sMoDE+InTDsoPaX3bUUOH33Yxn5Sw==",
       "dependencies": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.21",
         "postcss-values-parser": "^6.0.2"
       },
       "engines": {
@@ -976,9 +905,9 @@
       }
     },
     "node_modules/detective-sass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-4.0.1.tgz",
-      "integrity": "sha512-80zfpxux1krOrkxCHbtwvIs2gNHUBScnSqlGl0FvUuHVz8HD6vD2ov66OroMctyvzhM67fxhuEeVjIk18s6yTQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-4.1.1.tgz",
+      "integrity": "sha512-KSUoOdrLXxSZFnHpGyXufWUP6VkfSdSNC/uezbJkKIwy2i3px5NQPY5hWOR0k9OFlrBakucymD3Ap4d87zobUQ==",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
         "node-source-walk": "^5.0.0"
@@ -988,9 +917,9 @@
       }
     },
     "node_modules/detective-sass/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -999,9 +928,9 @@
       }
     },
     "node_modules/detective-scss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-3.0.0.tgz",
-      "integrity": "sha512-37MB/mhJyS45ngqfzd6eTbuLMoDgdZnH03ZOMW2m9WqJ/Rlbuc8kZAr0Ypovaf1DJiTRzy5mmxzOTja85jbzlA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-3.0.1.tgz",
+      "integrity": "sha512-Bv/t1dEKHCPJ9+byha7wKg4zda8IFk7KZpEX+ZJs2k1HsWIE3+FBeVFLtD3y9GYGfi8l7Sim3pULPz4+yLwW9A==",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
         "node-source-walk": "^5.0.0"
@@ -1011,9 +940,9 @@
       }
     },
     "node_modules/detective-scss/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -1022,39 +951,39 @@
       }
     },
     "node_modules/detective-stylus": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-2.0.1.tgz",
-      "integrity": "sha512-/Tvs1pWLg8eYwwV6kZQY5IslGaYqc/GACxjcaGudiNtN5nKCH6o2WnJK3j0gA3huCnoQcbv8X7oz/c1lnvE3zQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-3.0.0.tgz",
+      "integrity": "sha512-1xYTzbrduExqMYmte7Qk99IRA3Aa6oV7PYzd+3yDcQXkmENvyGF/arripri6lxRDdNYEb4fZFuHtNRAXbz3iAA==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12"
       }
     },
     "node_modules/detective-typescript": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-9.0.0.tgz",
-      "integrity": "sha512-lR78AugfUSBojwlSRZBeEqQ1l8LI7rbxOl1qTUnGLcjZQDjZmrZCb7R46rK8U8B5WzFvJrxa7fEBA8FoD/n5fA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-10.0.0.tgz",
+      "integrity": "sha512-1Y4Q96u93+LG3RBseA97ouX7LPYaB/QJNHwROTQiMTEZMff+p5VkquOI+RpRzDZCqo6IgyknMJELlrxNb9CQ1Q==",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "^5.13.0",
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0",
-        "typescript": "^4.5.5"
+        "@typescript-eslint/typescript-estree": "^5.58.0",
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1",
+        "typescript": "^5.0.4"
       },
       "engines": {
         "node": "^12.20.0 || ^14.14.0 || >=16.0.0"
       }
     },
     "node_modules/detective-typescript/node_modules/ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+      "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/detective-typescript/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -1301,18 +1230,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eslint/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/eslint/node_modules/globals": {
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -1346,23 +1263,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "node_modules/eslint/node_modules/optionator": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-      "dev": true,
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
     },
     "node_modules/eslint/node_modules/semver": {
       "version": "6.3.0",
@@ -1556,9 +1456,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -1733,29 +1633,29 @@
       "dev": true
     },
     "node_modules/get-amd-module-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-4.0.0.tgz",
-      "integrity": "sha512-GbBawUCuA2tY8ztiMiVo3e3P95gc2TVrfYFfpUHdHQA8WyxMCckK29bQsVKhYX8SUf+w6JLhL2LG8tSC0ANt9Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-4.1.0.tgz",
+      "integrity": "sha512-0e/eK6vTGCnSfQ6eYs3wtH05KotJYIP7ZIZEueP/KlA+0dIAEs8bYFvOd/U56w1vfjhJqBagUxVMyy9Tr/cViQ==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0"
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/get-amd-module-type/node_modules/ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+      "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/get-amd-module-type/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -2212,9 +2112,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2676,17 +2576,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -2980,11 +2869,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
     "node_modules/mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
@@ -3267,10 +3151,9 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -3288,9 +3171,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
+      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
       "funding": [
         {
           "type": "opencollective",
@@ -3299,10 +3182,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -3332,9 +3219,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -3343,22 +3236,22 @@
       }
     },
     "node_modules/precinct": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-9.0.1.tgz",
-      "integrity": "sha512-hVNS6JvfvlZ64B3ezKeGAcVhIuOvuAiSVzagHX/+KjVPkYWoCNkfyMgCl1bjDtAFQSlzi95NcS9ykUWrl1L1vA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-10.0.0.tgz",
+      "integrity": "sha512-+YKQ5tePjM0siR14p+Qhg9tLwN2uzByAtC2QgwLAU6lFm8lR8nNtPSPhYIsMyU0zvUeYheaPSd3Yn3/e45i33Q==",
       "dependencies": {
-        "commander": "^9.1.0",
-        "detective-amd": "^4.0.1",
-        "detective-cjs": "^4.0.0",
-        "detective-es6": "^3.0.0",
-        "detective-less": "^1.0.2",
-        "detective-postcss": "^6.0.1",
-        "detective-sass": "^4.0.1",
-        "detective-scss": "^3.0.0",
-        "detective-stylus": "^2.0.0",
-        "detective-typescript": "^9.0.0",
-        "module-definition": "^4.0.0",
-        "node-source-walk": "^5.0.0"
+        "@dependents/detective-less": "^3.0.1",
+        "commander": "^9.5.0",
+        "detective-amd": "^4.1.0",
+        "detective-cjs": "^4.1.0",
+        "detective-es6": "^3.0.1",
+        "detective-postcss": "^6.1.1",
+        "detective-sass": "^4.1.1",
+        "detective-scss": "^3.0.1",
+        "detective-stylus": "^3.0.0",
+        "detective-typescript": "^10.0.0",
+        "module-definition": "^4.1.0",
+        "node-source-walk": "^5.0.1"
       },
       "bin": {
         "precinct": "bin/cli.js"
@@ -3368,28 +3261,28 @@
       }
     },
     "node_modules/precinct/node_modules/ast-module-types": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-      "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+      "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g==",
       "engines": {
-        "node": ">=6.0"
+        "node": ">=12.0"
       }
     },
     "node_modules/precinct/node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "engines": {
         "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/precinct/node_modules/module-definition": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-4.0.0.tgz",
-      "integrity": "sha512-wntiAHV4lDn24BQn2kX6LKq0y85phHLHiv3aOPDF+lIs06kVjEMTe/ZTdrbVLnQV5FQsjik21taknvMhKY1Cug==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-4.1.0.tgz",
+      "integrity": "sha512-rHXi/DpMcD2qcKbPCTklDbX9lBKJrUSl971TW5l6nMpqKCIlzJqmQ8cfEF5M923h2OOLHPDVlh5pJxNyV+AJlw==",
       "dependencies": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0"
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1"
       },
       "bin": {
         "module-definition": "bin/cli.js"
@@ -3399,9 +3292,9 @@
       }
     },
     "node_modules/precinct/node_modules/node-source-walk": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-      "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+      "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
       "dependencies": {
         "@babel/parser": "^7.0.0"
       },
@@ -4156,15 +4049,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/underscore": {
@@ -4577,6 +4470,25 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.7.tgz",
       "integrity": "sha512-oWR02Ubp4xTLCAqPRiNIuMVgNO5Aif/xpXtabhzW2HWUD47XJsAB4Zd/Rg30+XeQA3juXigV7hlquOTmwqLiwg=="
     },
+    "@dependents/detective-less": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dependents/detective-less/-/detective-less-3.0.1.tgz",
+      "integrity": "sha512-NjjCPJbx/za2287T6gnC5zD2IFSplro1evaTV9yvx3jnPpHi7s8PwJvh9vvJRFnMx5nbakodwNOnFvk8+9YQTg==",
+      "requires": {
+        "gonzales-pe": "^4.3.0",
+        "node-source-walk": "^5.0.0"
+      },
+      "dependencies": {
+        "node-source-walk": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
+          "requires": {
+            "@babel/parser": "^7.0.0"
+          }
+        }
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4646,17 +4558,17 @@
       "dev": true
     },
     "@typescript-eslint/types": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.47.0.tgz",
-      "integrity": "sha512-eslFG0Qy8wpGzDdYKu58CEr3WLkjwC5Usa6XbuV89ce/yN5RITLe1O8e+WFEuxnfftHiJImkkOBADj58ahRxSg=="
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
+      "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g=="
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.47.0.tgz",
-      "integrity": "sha512-LxfKCG4bsRGq60Sqqu+34QT5qT2TEAHvSCCJ321uBWywgE2dS0LKcu5u+3sMGo+Vy9UmLOhdTw5JHzePV/1y4Q==",
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
+      "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
       "requires": {
-        "@typescript-eslint/types": "5.47.0",
-        "@typescript-eslint/visitor-keys": "5.47.0",
+        "@typescript-eslint/types": "5.58.0",
+        "@typescript-eslint/visitor-keys": "5.58.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4664,26 +4576,10 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.4",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "is-glob": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-          "requires": {
-            "is-extglob": "^2.1.1"
-          }
-        },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
+          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -4691,18 +4587,18 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.47.0.tgz",
-      "integrity": "sha512-ByPi5iMa6QqDXe/GmT/hR6MZtVPi0SqMQPDx15FczCBXJo/7M8T88xReOALAfpBLm+zxpPfmhuEvPb577JRAEg==",
+      "version": "5.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
+      "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
       "requires": {
-        "@typescript-eslint/types": "5.47.0",
+        "@typescript-eslint/types": "5.58.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
+          "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ=="
         }
       }
     },
@@ -4918,33 +4814,6 @@
           "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
           "dev": true
         },
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "dev": true,
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "dev": true,
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "is-binary-path": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4954,12 +4823,6 @@
             "binary-extensions": "^2.0.0"
           }
         },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
-        },
         "readdirp": {
           "version": "3.5.0",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -4967,15 +4830,6 @@
           "dev": true,
           "requires": {
             "picomatch": "^2.2.1"
-          }
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^7.0.0"
           }
         }
       }
@@ -5155,9 +5009,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       },
@@ -5195,25 +5049,25 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "detective-amd": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-4.0.1.tgz",
-      "integrity": "sha512-bDo22IYbJ8yzALB0Ow5CQLtyhU1BpDksLB9dsWHI9Eh0N3OQR6aQqhjPsNDd69ncYwRfL1sTo7OA9T3VRVSe2Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-4.1.0.tgz",
+      "integrity": "sha512-XlQrGjGEnMFjKbep0/S/T7XICxf25LFMP6Ug+Iw/Ww/MHUBzfy8QETCzamO1JlAMYPmkChDh21/NS/csG0FwGg==",
       "requires": {
-        "ast-module-types": "^3.0.0",
+        "ast-module-types": "^4.0.0",
         "escodegen": "^2.0.0",
-        "get-amd-module-type": "^4.0.0",
-        "node-source-walk": "^5.0.0"
+        "get-amd-module-type": "^4.1.0",
+        "node-source-walk": "^5.0.1"
       },
       "dependencies": {
         "ast-module-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-          "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+          "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g=="
         },
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -5221,23 +5075,23 @@
       }
     },
     "detective-cjs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-4.0.0.tgz",
-      "integrity": "sha512-VsD6Yo1+1xgxJWoeDRyut7eqZ8EWaJI70C5eanSAPcBHzenHZx0uhjxaaEfIm0cHII7dBiwU98Orh44bwXN2jg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-4.1.0.tgz",
+      "integrity": "sha512-QxzMwt5MfPLwS7mG30zvnmOvHLx5vyVvjsAV6gQOyuMoBR5G1DhS1eJZ4P10AlH+HSnk93mTcrg3l39+24XCtg==",
       "requires": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0"
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1"
       },
       "dependencies": {
         "ast-module-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-          "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+          "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g=="
         },
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -5245,56 +5099,46 @@
       }
     },
     "detective-es6": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-3.0.0.tgz",
-      "integrity": "sha512-Uv2b5Uih7vorYlqGzCX+nTPUb4CMzUAn3VPHTV5p5lBkAN4cAApLGgUz4mZE2sXlBfv4/LMmeP7qzxHV/ZcfWA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-3.0.1.tgz",
+      "integrity": "sha512-evPeYIEdK1jK3Oji5p0hX4sPV/1vK+o4ihcWZkMQE6voypSW/cIBiynOLxQk5KOOQbdP8oOAsYqouMTYO5l1sw==",
       "requires": {
         "node-source-walk": "^5.0.0"
       },
       "dependencies": {
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
         }
       }
     },
-    "detective-less": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.2.tgz",
-      "integrity": "sha512-Rps1xDkEEBSq3kLdsdnHZL1x2S4NGDcbrjmd4q+PykK5aJwDdP5MBgrJw1Xo+kyUHuv3JEzPqxr+Dj9ryeDRTA==",
-      "requires": {
-        "debug": "^4.0.0",
-        "gonzales-pe": "^4.2.3",
-        "node-source-walk": "^4.0.0"
-      }
-    },
     "detective-postcss": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.0.tgz",
-      "integrity": "sha512-ZFZnEmUrL2XHAC0j/4D1fdwZbo/anAcK84soJh7qc7xfx2Kc8gFO5Bk5I9jU7NLC/OAF1Yho1GLxEDnmQnRH2A==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/detective-postcss/-/detective-postcss-6.1.1.tgz",
+      "integrity": "sha512-mX62A6chiafyFW9AwGF6B/uVU+F3hGMZwXDqCHe+NjmU/M5jlDBazdXb1sMoDE+InTDsoPaX3bUUOH33Yxn5Sw==",
       "requires": {
         "is-url": "^1.2.4",
-        "postcss": "^8.4.12",
+        "postcss": "^8.4.21",
         "postcss-values-parser": "^6.0.2"
       }
     },
     "detective-sass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-4.0.1.tgz",
-      "integrity": "sha512-80zfpxux1krOrkxCHbtwvIs2gNHUBScnSqlGl0FvUuHVz8HD6vD2ov66OroMctyvzhM67fxhuEeVjIk18s6yTQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-4.1.1.tgz",
+      "integrity": "sha512-KSUoOdrLXxSZFnHpGyXufWUP6VkfSdSNC/uezbJkKIwy2i3px5NQPY5hWOR0k9OFlrBakucymD3Ap4d87zobUQ==",
       "requires": {
         "gonzales-pe": "^4.3.0",
         "node-source-walk": "^5.0.0"
       },
       "dependencies": {
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -5302,18 +5146,18 @@
       }
     },
     "detective-scss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-3.0.0.tgz",
-      "integrity": "sha512-37MB/mhJyS45ngqfzd6eTbuLMoDgdZnH03ZOMW2m9WqJ/Rlbuc8kZAr0Ypovaf1DJiTRzy5mmxzOTja85jbzlA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-3.0.1.tgz",
+      "integrity": "sha512-Bv/t1dEKHCPJ9+byha7wKg4zda8IFk7KZpEX+ZJs2k1HsWIE3+FBeVFLtD3y9GYGfi8l7Sim3pULPz4+yLwW9A==",
       "requires": {
         "gonzales-pe": "^4.3.0",
         "node-source-walk": "^5.0.0"
       },
       "dependencies": {
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -5321,30 +5165,30 @@
       }
     },
     "detective-stylus": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-2.0.1.tgz",
-      "integrity": "sha512-/Tvs1pWLg8eYwwV6kZQY5IslGaYqc/GACxjcaGudiNtN5nKCH6o2WnJK3j0gA3huCnoQcbv8X7oz/c1lnvE3zQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-3.0.0.tgz",
+      "integrity": "sha512-1xYTzbrduExqMYmte7Qk99IRA3Aa6oV7PYzd+3yDcQXkmENvyGF/arripri6lxRDdNYEb4fZFuHtNRAXbz3iAA=="
     },
     "detective-typescript": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-9.0.0.tgz",
-      "integrity": "sha512-lR78AugfUSBojwlSRZBeEqQ1l8LI7rbxOl1qTUnGLcjZQDjZmrZCb7R46rK8U8B5WzFvJrxa7fEBA8FoD/n5fA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-10.0.0.tgz",
+      "integrity": "sha512-1Y4Q96u93+LG3RBseA97ouX7LPYaB/QJNHwROTQiMTEZMff+p5VkquOI+RpRzDZCqo6IgyknMJELlrxNb9CQ1Q==",
       "requires": {
-        "@typescript-eslint/typescript-estree": "^5.13.0",
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0",
-        "typescript": "^4.5.5"
+        "@typescript-eslint/typescript-estree": "^5.58.0",
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1",
+        "typescript": "^5.0.4"
       },
       "dependencies": {
         "ast-module-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-          "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+          "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g=="
         },
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -5520,15 +5364,6 @@
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -5553,20 +5388,6 @@
           "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
           "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
           "dev": true
-        },
-        "optionator": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-          "dev": true,
-          "requires": {
-            "deep-is": "~0.1.3",
-            "fast-levenshtein": "~2.0.6",
-            "levn": "~0.3.0",
-            "prelude-ls": "~1.1.2",
-            "type-check": "~0.3.2",
-            "word-wrap": "~1.2.3"
-          }
         },
         "semver": {
           "version": "6.3.0",
@@ -5736,9 +5557,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -5872,23 +5693,23 @@
       "dev": true
     },
     "get-amd-module-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-4.0.0.tgz",
-      "integrity": "sha512-GbBawUCuA2tY8ztiMiVo3e3P95gc2TVrfYFfpUHdHQA8WyxMCckK29bQsVKhYX8SUf+w6JLhL2LG8tSC0ANt9Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-4.1.0.tgz",
+      "integrity": "sha512-0e/eK6vTGCnSfQ6eYs3wtH05KotJYIP7ZIZEueP/KlA+0dIAEs8bYFvOd/U56w1vfjhJqBagUxVMyy9Tr/cViQ==",
       "requires": {
-        "ast-module-types": "^3.0.0",
-        "node-source-walk": "^5.0.0"
+        "ast-module-types": "^4.0.0",
+        "node-source-walk": "^5.0.1"
       },
       "dependencies": {
         "ast-module-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-          "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+          "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g=="
         },
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -6248,9 +6069,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -6613,13 +6434,6 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
-      },
-      "dependencies": {
-        "picomatch": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
-        }
       }
     },
     "mimic-fn": {
@@ -6821,11 +6635,6 @@
         "requirejs": "^2.3.5",
         "requirejs-config-file": "^4.0.0"
       }
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -7046,10 +6855,9 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pkginfo": {
       "version": "0.4.1",
@@ -7058,19 +6866,19 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.22.tgz",
+      "integrity": "sha512-XseknLAfRHzVWjCEtdviapiBtfLdgyzExD50Rg2ePaucEesyh8Wv4VPdW0nbyDa1ydbrAxV19jvMT4+LFmcNUA==",
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
       "dependencies": {
         "nanoid": {
-          "version": "3.3.4",
-          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-          "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+          "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
         }
       }
     },
@@ -7092,47 +6900,47 @@
       }
     },
     "precinct": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/precinct/-/precinct-9.0.1.tgz",
-      "integrity": "sha512-hVNS6JvfvlZ64B3ezKeGAcVhIuOvuAiSVzagHX/+KjVPkYWoCNkfyMgCl1bjDtAFQSlzi95NcS9ykUWrl1L1vA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-10.0.0.tgz",
+      "integrity": "sha512-+YKQ5tePjM0siR14p+Qhg9tLwN2uzByAtC2QgwLAU6lFm8lR8nNtPSPhYIsMyU0zvUeYheaPSd3Yn3/e45i33Q==",
       "requires": {
-        "commander": "^9.1.0",
-        "detective-amd": "^4.0.1",
-        "detective-cjs": "^4.0.0",
-        "detective-es6": "^3.0.0",
-        "detective-less": "^1.0.2",
-        "detective-postcss": "^6.0.1",
-        "detective-sass": "^4.0.1",
-        "detective-scss": "^3.0.0",
-        "detective-stylus": "^2.0.0",
-        "detective-typescript": "^9.0.0",
-        "module-definition": "^4.0.0",
-        "node-source-walk": "^5.0.0"
+        "@dependents/detective-less": "^3.0.1",
+        "commander": "^9.5.0",
+        "detective-amd": "^4.1.0",
+        "detective-cjs": "^4.1.0",
+        "detective-es6": "^3.0.1",
+        "detective-postcss": "^6.1.1",
+        "detective-sass": "^4.1.1",
+        "detective-scss": "^3.0.1",
+        "detective-stylus": "^3.0.0",
+        "detective-typescript": "^10.0.0",
+        "module-definition": "^4.1.0",
+        "node-source-walk": "^5.0.1"
       },
       "dependencies": {
         "ast-module-types": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-3.0.0.tgz",
-          "integrity": "sha512-CMxMCOCS+4D+DkOQfuZf+vLrSEmY/7xtORwdxs4wtcC1wVgvk2MqFFTwQCFhvWsI4KPU9lcWXPI8DgRiz+xetQ=="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-4.0.0.tgz",
+          "integrity": "sha512-Kd0o8r6CDazJGCRzs8Ivpn0xj19oNKrULhoJFzhGjRsLpekF2zyZs9Ukz+JvZhWD6smszfepakTFhAaYpsI12g=="
         },
         "commander": {
-          "version": "9.4.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-          "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
         },
         "module-definition": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-4.0.0.tgz",
-          "integrity": "sha512-wntiAHV4lDn24BQn2kX6LKq0y85phHLHiv3aOPDF+lIs06kVjEMTe/ZTdrbVLnQV5FQsjik21taknvMhKY1Cug==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-4.1.0.tgz",
+          "integrity": "sha512-rHXi/DpMcD2qcKbPCTklDbX9lBKJrUSl971TW5l6nMpqKCIlzJqmQ8cfEF5M923h2OOLHPDVlh5pJxNyV+AJlw==",
           "requires": {
-            "ast-module-types": "^3.0.0",
-            "node-source-walk": "^5.0.0"
+            "ast-module-types": "^4.0.0",
+            "node-source-walk": "^5.0.1"
           }
         },
         "node-source-walk": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.0.tgz",
-          "integrity": "sha512-58APXoMXpmmU+oVBJFajhTCoD8d/OGtngnVAWzIo2A8yn0IXwBzvIVIsTzoie/SrA37u+1hnpNz2HMWx/VIqlw==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-5.0.1.tgz",
+          "integrity": "sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==",
           "requires": {
             "@babel/parser": "^7.0.0"
           }
@@ -7690,9 +7498,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg=="
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
     },
     "underscore": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "debug": "^4.3.1",
     "filing-cabinet": "^3.0.1",
     "precinct": "^9.0.0",
-    "typescript": "^4.0.0"
+    "typescript": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "esm": "^3.2.25",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "commander": "^2.20.3",
     "debug": "^4.3.1",
     "filing-cabinet": "^3.0.1",
-    "precinct": "^9.0.0",
-    "typescript": "^4.0.0 || ^5.0.0"
+    "precinct": "^10.0.0",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "esm": "^3.2.25",


### PR DESCRIPTION
Bumping TS to 5.x, to allow users to smoothly move to TS 5.x.

As TS team does not follow semver at all, accepting 4.x or 4.x||5.x should be more or less as likely to have breakings.