### PR TITLE
- Added includeCore and includeNonExisting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ const tree = dependencyTree({
   }, // optional
   filter: path => path.indexOf('node_modules') === -1, // optional
   nonExistent: [], // optional
-  noTypeDefinitions: false // optional
+  noTypeDefinitions: false, // optional
+  includeCore: false, // optional, if true include node.js core modules (for example: "fs"), they will be prefixed with ':!EXISTS: '
+  includeNonExisting: false // optional, if true include unresolved dependencies, they will be prefixed with ':!EXISTS: '
 });
 
 // Returns a post-order traversal (list form) of the tree with duplicate sub-trees pruned.

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports.toList = function(options = {}) {
  */
 module.exports._getDependencies = function(config = {}) {
   const precinctOptions = config.detectiveConfig;
-  precinctOptions.includeCore = false;
+
   let dependencies;
 
   try {
@@ -112,6 +112,9 @@ module.exports._getDependencies = function(config = {}) {
     if (!result) {
       debug(`skipping an empty filepath resolution for partial: ${dependency}`);
       config.nonExistent.push(dependency);
+      if(config.includeNonExisting) {
+		    resolvedDependencies.push(":!EXISTS: " + dependency);
+		  }
       continue;
     }
 
@@ -120,6 +123,9 @@ module.exports._getDependencies = function(config = {}) {
     if (!exists) {
       config.nonExistent.push(dependency);
       debug(`skipping non-empty but non-existent resolution: ${result} for partial: ${dependency}`);
+      if(config.includeNonExisting) {
+		    resolvedDependencies.push(":!EXISTS: " + dependency);
+		  }
       continue;
     }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,8 @@ module.exports = class Config {
     this.webpackConfig = options.webpackConfig;
     this.nodeModulesConfig = options.nodeModulesConfig;
     this.detectiveConfig = options.detective || options.detectiveConfig || {};
+    this.detectiveConfig.includeCore = this.includeCore = options.includeCore || false;
+    this.detectiveConfig.includeNonExisting = this.includeNonExisting = options.includeNonExisting || options.includeCore || false;
     this.tsConfig = options.tsConfig;
     this.noTypeDefinitions = options.noTypeDefinitions;
 

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -139,6 +139,26 @@ describe('dependencyTree', () => {
     assert.ok(!Object.keys(subTree).includes('notReal'));
   });
 
+  it('test includeNonExisting=true', () => {
+    const directory = path.join(__dirname, '/fixtures/onlyRealDeps');
+    const filename = path.normalize(`${directory}/a.js`);
+
+    const tree = dependencyTree({ filename, directory, includeNonExisting: true });
+    const subTree = tree[filename];
+
+    assert.ok(Object.keys(subTree).includes( ':!EXISTS: not-real'));
+  });
+
+  it('test includeCore=true', () => {
+    const directory = path.join(__dirname, '/fixtures/onlyRealDeps');
+    const filename = path.normalize(`${directory}/a.js`);
+
+    const tree = dependencyTree({ filename, directory, includeCore: true });
+    const subTree = tree[filename];
+
+    assert.ok(Object.keys(subTree).includes( ':!EXISTS: path'));
+  });
+
   it('does not choke on cyclic dependencies', () => {
     mockfs({
       [path.join(__dirname, '/cyclic')]: {


### PR DESCRIPTION
- Added includeNonExisting if true include unresolved dependencies, they will be prefixed with ':!EXISTS: '
- Added includeCore to include core modules (for example: "fs"), they will also be prefixed with ':!EXISTS: ' (because they don't really exist in filesystem)

The WHY:
- Because I want to know which of dependend packages use Node.js core modules and thus require polyfilling or can't be used inside browser.
