### PR TITLE
Fix #135 fix(tsConfig): path mapping by filing-cabinet

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const list = dependencyTree.toList({
 * `requireConfig`: path to a requirejs config for AMD modules (allows for the result of aliased module paths)
 * `webpackConfig`: path to a webpack config for aliased modules
 * `tsConfig`: path to a typescript config (or a preloaded object representing the typescript config)
+* `tsConfigPath`: a (virtual) path to typescript config file when `tsConfig` option is given as an object, not a string. Needed to calculate [Path Mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping). If not given when `tsConfig` is an object, **Path Mapping** is ignored. This is not needed when `tsConfig` is given as a path string.
 * `nodeModulesConfig`: config for resolving entry file for node_modules
 * `visited`: object used for avoiding redundant subtree generations via memoization.
 * `nonExistent`: array used for storing the list of partial paths that do not exist

--- a/index.js
+++ b/index.js
@@ -106,6 +106,7 @@ module.exports._getDependencies = function(config = {}) {
       webpackConfig: config.webpackConfig,
       nodeModulesConfig: config.nodeModulesConfig,
       tsConfig: config.tsConfig,
+      tsConfigPath: config.tsConfigPath,
       noTypeDefinitions: config.noTypeDefinitions
     });
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,8 +18,8 @@ module.exports = class Config {
     this.nodeModulesConfig = options.nodeModulesConfig;
     this.detectiveConfig = options.detective || options.detectiveConfig || {};
     this.tsConfig = options.tsConfig;
+    this.tsConfigPath = options.tsConfigPath;
     this.noTypeDefinitions = options.noTypeDefinitions;
-
     this.filter = options.filter;
 
     if (!this.filename) throw new Error('filename not given');
@@ -31,6 +31,7 @@ module.exports = class Config {
       const ts = require('typescript');
       const tsParsedConfig = ts.readJsonConfigFile(this.tsConfig, ts.sys.readFile);
       const obj = ts.parseJsonSourceFileConfigFileContent(tsParsedConfig, ts.sys, path.dirname(this.tsConfig));
+      this.tsConfigPath ||= this.tsConfig;
       this.tsConfig = obj.raw;
     }
 

--- a/test/test.mjs
+++ b/test/test.mjs
@@ -964,6 +964,18 @@ describe('dependencyTree', () => {
 
         assert.equal(typeof config.tsConfig, 'object');
       });
+
+      it('includes the tsConfigPath so filing-cabinet can still resolve compilerOptions.paths correctly', () => {
+        const directory = path.join(__dirname, 'fixtures/ts');
+        const tsConfigPath = path.join(directory, '.tsconfig');
+        const config = new Config({
+          filename: 'foo',
+          directory: 'bar',
+          tsConfig: tsConfigPath
+        });
+
+        assert.equal(config.tsConfigPath, tsConfigPath);
+      });
     });
 
     describe('when cloning', () => {


### PR DESCRIPTION
Adding tests to #138 

I saw that [this PR](https://github.com/dependents/node-dependency-tree/pull/138) may be held up [because it needed tests](https://github.com/dependents/node-dependency-tree/pull/138#issuecomment-2033828732). I'm happy to get the ball rolling on that—this adds a test to the config lib. Happy to add more if you can suggest where.