### PR TITLE
refactor: rename getDirectory to getLocalConfigDirectory and tweak it

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,7 @@ function traverse(config = {}) {
   for (const dependency of dependencies) {
     const localConfig = config.clone();
     localConfig.filename = dependency;
-    localConfig.directory = getDirectory(localConfig);
+    localConfig.directory = getLocalConfigDirectory(localConfig);
 
     if (localConfig.isListForm) {
       for (const item of traverse(localConfig)) {
@@ -187,24 +187,35 @@ function dedupeNonExistent(nonExistent) {
   }
 }
 
-// For files inside node_modules, resolve from the package root rather than the app root
-function getDirectory(localConfig) {
-  if (!localConfig.filename.includes('node_modules')) {
-    return localConfig.directory;
+// If the file is in a node_modules directory, we want to resolve the root of the package,
+// not the file itself, since the file may be buried in a subdirectory and not contain all
+// of the package's dependencies
+function getLocalConfigDirectory(localConfig) {
+  const { filename, directory } = localConfig;
+
+  if (!filename.includes('node_modules')) {
+    return directory;
   }
 
-  return getProjectPath(path.dirname(localConfig.filename)) || localConfig.directory;
-}
+  const dir = path.dirname(filename);
+  const parts = dir.split('node_modules');
 
-function getProjectPath(filename) {
-  try {
-    const nodeModuleParts = filename.split('node_modules');
-    const packageSubPathPath = nodeModuleParts.pop().split(path.sep).filter(Boolean);
-    const packageName = packageSubPathPath[0].startsWith('@') ? `${packageSubPathPath[0]}${path.sep}${packageSubPathPath[1]}` : packageSubPathPath[0];
-
-    return path.normalize([...nodeModuleParts, `${path.sep}${packageName}`].join('node_modules'));
-  } catch {
-    debug(`Could not determine the root directory of package file ${filename}. Using default`);
-    return null;
+  if (parts.length < 2) {
+    return directory;
   }
+
+  const afterNodeModules = parts.pop();
+  if (!afterNodeModules) {
+    return directory;
+  }
+
+  const segments = afterNodeModules.split(path.sep).filter(Boolean);
+  if (segments.length === 0) {
+    return directory;
+  }
+
+  const packageName = segments[0].startsWith('@') ? `${segments[0]}${path.sep}${segments[1]}` : segments[0];
+  const projectPath = path.normalize(`${parts.join('node_modules')}node_modules${path.sep}${packageName}`);
+
+  return projectPath;
 }

--- a/test/dependency-tree.test.mjs
+++ b/test/dependency-tree.test.mjs
@@ -408,4 +408,98 @@ describe('dependencyTree', () => {
       assert.deepEqual(tree[filename], []);
     });
   });
+
+  describe('getLocalConfigDirectory', () => {
+    it('resolves sub-dependencies of a file whose name contains "node_modules" but whose directory does not', () => {
+      const directory = fixtures('nodeModulesInName');
+      mockfs({
+        [directory]: {
+          'a.js': 'var x = require("./node_modules.helper");',
+          'node_modules.helper.js': 'var y = require("./sub");',
+          'sub.js': 'export default 1;'
+        }
+      });
+
+      const filename = path.join(directory, 'a.js');
+      const helperPath = path.join(directory, 'node_modules.helper.js');
+      const subPath = path.join(directory, 'sub.js');
+
+      const list = dependencyTree.toList({ filename, directory });
+
+      assert.equal(list.includes(helperPath), true);
+      assert.equal(list.includes(subPath), true);
+    });
+
+    it('resolves the correct root directory for a scoped package in node_modules', () => {
+      const directory = fixtures('scopedPackage');
+      mockfs({
+        [directory]: {
+          'a.js': 'var x = require("./node_modules/@scope/pkg/index");',
+          node_modules: {
+            '@scope': {
+              pkg: {
+                'index.js': 'var y = require("./util");',
+                'util.js': 'export default 1;'
+              }
+            }
+          }
+        }
+      });
+
+      const filename = path.join(directory, 'a.js');
+      const indexPath = path.join(directory, 'node_modules', '@scope', 'pkg', 'index.js');
+      const utilPath = path.join(directory, 'node_modules', '@scope', 'pkg', 'util.js');
+
+      const list = dependencyTree.toList({ filename, directory });
+
+      assert.equal(list.includes(indexPath), true);
+      assert.equal(list.includes(utilPath), true);
+    });
+
+    it('resolves sub-dependencies for a package inside nested node_modules', () => {
+      const directory = fixtures('nestedNodeModules');
+      mockfs({
+        [directory]: {
+          'a.js': 'var x = require("./node_modules/pkg-a/index");',
+          node_modules: {
+            'pkg-a': {
+              'index.js': 'var y = require("./node_modules/pkg-b/index");',
+              node_modules: {
+                'pkg-b': {
+                  'index.js': 'export default 1;'
+                }
+              }
+            }
+          }
+        }
+      });
+
+      const filename = path.join(directory, 'a.js');
+      const pkgAPath = path.join(directory, 'node_modules', 'pkg-a', 'index.js');
+      const pkgBPath = path.join(directory, 'node_modules', 'pkg-a', 'node_modules', 'pkg-b', 'index.js');
+
+      const list = dependencyTree.toList({ filename, directory });
+
+      assert.equal(list.includes(pkgAPath), true);
+      assert.equal(list.includes(pkgBPath), true);
+    });
+
+    it('does not throw when a file sits directly inside node_modules/ without a package subfolder', () => {
+      const directory = fixtures('directNodeModules');
+      mockfs({
+        [directory]: {
+          'a.js': 'var x = require("./node_modules/direct");',
+          node_modules: {
+            'direct.js': 'export default 1;'
+          }
+        }
+      });
+
+      const filename = path.join(directory, 'a.js');
+
+      assert.doesNotThrow(() => {
+        dependencyTree.toList({ filename, directory });
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Rename getDirectory to getLocalConfigDirectory
- Remove getProjectPath and inline its logic into getLocalConfigDirectory
- Return directory early if parts.length < 2 after splitting on node_modules
- Return directory early if afterNodeModules is empty
- Return directory early if segments is empty after filtering
- Fix path reconstruction for nested node_modules using parts.join('node_modules')
- Return directory instead of null in the catch block

Non-whitespace diff: https://github.com/dependents/node-dependency-tree/pull/206/changes?w=1