### PR TITLE
fix: stream CLI JSON output to prevent RangeError on large trees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,7 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:ci
+
+      - name: Run slow tests
+        if: matrix.os == 'ubuntu-latest' && (matrix.node == 18 || matrix.node == 24)
+        run: npm run mocha:slow

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,9 +2,11 @@
 
 'use strict';
 
+const process = require('node:process');
 const { program } = require('commander');
 const dependencyTree = require('../index.js');
 const { name, description, version } = require('../package.json');
+const { writeJsonToStream } = require('../lib/write-json-stream.js');
 
 program
   .name(name)
@@ -38,5 +40,6 @@ if (cliOptions.listForm) {
 } else {
   const tree = dependencyTree(options);
 
-  console.log(JSON.stringify(tree));
+  writeJsonToStream(tree, process.stdout);
+  process.stdout.write('\n');
 }

--- a/lib/write-json-stream.js
+++ b/lib/write-json-stream.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * Writes value as JSON directly to stream, chunk by chunk, without first
+ * serializing the whole tree into a single string.
+ *
+ * JSON.stringify buffers its entire output as one JavaScript string before
+ * writing anything. For large dependency trees (e.g. nx monorepos) that
+ * string can exceed V8's string-length limit and crash with
+ * "RangeError: Invalid string length". Writing incrementally avoids that
+ * limit entirely - each chunk is a small string, never the full tree.
+ *
+ * Output is identical to JSON.stringify for any object tree.
+ *
+ * @param {unknown} value
+ * @param {import('node:stream').Writable} stream
+ */
+function writeJsonToStream(value, stream) {
+  if (value === null || typeof value !== 'object') {
+    stream.write(JSON.stringify(value));
+    return;
+  }
+
+  stream.write('{');
+
+  let first = true;
+
+  for (const [key, val] of Object.entries(value)) {
+    if (!first) stream.write(',');
+
+    first = false;
+    stream.write(JSON.stringify(key));
+    stream.write(':');
+    writeJsonToStream(val, stream);
+  }
+
+  stream.write('}');
+}
+
+module.exports = { writeJsonToStream };

--- a/lib/write-json-stream.js
+++ b/lib/write-json-stream.js
@@ -4,14 +4,6 @@
  * Writes value as JSON directly to stream, chunk by chunk, without first
  * serializing the whole tree into a single string.
  *
- * JSON.stringify buffers its entire output as one JavaScript string before
- * writing anything. For large dependency trees (e.g. nx monorepos) that
- * string can exceed V8's string-length limit and crash with
- * "RangeError: Invalid string length". Writing incrementally avoids that
- * limit entirely - each chunk is a small string, never the full tree.
- *
- * Output is identical to JSON.stringify for any object tree.
- *
  * @param {unknown} value
  * @param {import('node:stream').Writable} stream
  */

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint": "xo",
     "fix": "xo --fix",
     "mocha": "mocha \"test/*.test.mjs\"",
+    "mocha:slow": "mocha \"test/slow/*.test.mjs\"",
     "test": "npm run lint && npm run mocha",
     "test:ci": "c8 npm run mocha"
   },

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -38,4 +38,46 @@ describe('cli', () => {
       assert.equal(path.resolve(lines.at(-1)), path.resolve(entry));
     });
   });
+
+  describe('default (non-list) output', () => {
+    it('emits valid JSON with the entry file as the top-level key', () => {
+      const dir = fixtures('commonjs');
+      const entry = fixtures('commonjs', 'a.js');
+
+      const result = spawnSync(process.execPath, [cliPath, '--directory', dir, entry], {
+        encoding: 'utf8'
+      });
+      const tree = JSON.parse(result.stdout);
+      const keys = Object.keys(tree);
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(keys.length, 1);
+      assert.equal(path.resolve(keys[0]), path.resolve(entry));
+    });
+
+    it('does not crash or repeat shared subtrees when a dependency is reachable via multiple paths', () => {
+      // amd/a.js -> b.js and c.js; amd/b.js -> c.js (c is a shared dep)
+      const dir = fixtures('amd');
+      const entry = path.join(dir, 'a.js');
+      const bPath = path.join(dir, 'b.js');
+      const cPath = path.join(dir, 'c.js');
+
+      const result = spawnSync(process.execPath, [cliPath, '--directory', dir, entry], {
+        encoding: 'utf8'
+      });
+      const tree = JSON.parse(result.stdout);
+      // entry file is the sole top-level key
+      const topKeys = Object.keys(tree);
+      // c.js is reachable via two paths (directly from a.js, and via b.js).
+      // The JSON must remain structurally valid and include c.js at both locations.
+      const entrySubtree = tree[topKeys[0]];
+
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(topKeys.length, 1);
+      assert.equal(path.resolve(topKeys[0]), path.resolve(entry));
+      assert.equal(Object.hasOwn(entrySubtree, bPath), true);
+      assert.equal(Object.hasOwn(entrySubtree, cPath), true);
+      assert.equal(Object.hasOwn(entrySubtree[bPath], cPath), true);
+    });
+  });
 });

--- a/test/slow/cli.test.mjs
+++ b/test/slow/cli.test.mjs
@@ -1,0 +1,61 @@
+import { strict as assert } from 'node:assert';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const cliPath = fileURLToPath(new URL('../../bin/cli.js', import.meta.url));
+
+describe('cli (slow)', () => {
+  describe('default (non-list) output', () => {
+    it('does not crash where JSON.stringify would exceed V8 string length limits (issue #141)', function() {
+      this.timeout(60_000);
+
+      // Build a diamond dependency fixture: every pair at depth k requires both
+      // files at depth k+1. traverse() memoises via config.visited and returns
+      // the SAME JS object reference for every re-visit of a file, so
+      // JSON.stringify serializes the shared subtrees exponentially - at depth 22
+      // the output exceeds V8's ~512 MB string-length limit and crashes with
+      // "RangeError: Invalid string length". writeJsonToStream writes in small
+      // chunks and never accumulates a single string, so it succeeds.
+      const DEPTH = 22;
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-diamond-'));
+
+      try {
+        fs.writeFileSync(path.join(tmpDir, `level_${DEPTH - 1}_a.js`), '"use strict";\n');
+        fs.writeFileSync(path.join(tmpDir, `level_${DEPTH - 1}_b.js`), '"use strict";\n');
+
+        for (let k = DEPTH - 2; k >= 0; k--) {
+          const content = `
+            'use strict';
+            const a = require('./level_${k + 1}_a');
+            const b = require('./level_${k + 1}_b');
+          `;
+
+          fs.writeFileSync(path.join(tmpDir, `level_${k}_a.js`), content);
+          fs.writeFileSync(path.join(tmpDir, `level_${k}_b.js`), content);
+        }
+
+        const entry = path.join(tmpDir, 'entry.js');
+
+        fs.writeFileSync(entry, `
+          'use strict';
+          const a = require('./level_0_a');
+          const b = require('./level_0_b');
+        `);
+
+        const result = spawnSync(
+          process.execPath,
+          [cliPath, '--directory', tmpDir, entry],
+          { stdio: ['ignore', 'ignore', 'pipe'], encoding: 'utf8' }
+        );
+
+        assert.equal(result.status, 0, result.stderr);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+});

--- a/test/write-json-stream.test.mjs
+++ b/test/write-json-stream.test.mjs
@@ -1,0 +1,82 @@
+import { strict as assert } from 'node:assert';
+import { writeJsonToStream } from '../lib/write-json-stream.js';
+
+function collect(value) {
+  const chunks = [];
+  writeJsonToStream(value, {
+    write: c => chunks.push(c)
+  });
+
+  return chunks.join('');
+}
+
+describe('writeJsonToStream', () => {
+  it('produces output identical to JSON.stringify', () => {
+    const tree = {
+      'a.js': {
+        'b.js': {},
+        'c.js': {}
+      },
+      'd.js': {}
+    };
+
+    assert.equal(collect(tree), JSON.stringify(tree));
+  });
+
+  it('serializes null and other non-object values via JSON.stringify', () => {
+    assert.equal(collect(null), 'null');
+    assert.equal(collect(42), '42');
+    assert.equal(collect('hello'), '"hello"');
+  });
+
+  it('writes multiple small chunks rather than one large string', () => {
+    // For { a: { b: {} } } the call sequence is:
+    //   { "a.js" : { "b.js" : { } } } <- 10 separate write calls
+    // If the function called write exactly once it would be no different
+    // from console.log(JSON.stringify(tree)).
+    const tree = {
+      'a.js': {
+        'b.js': {}
+      }
+    };
+    const chunks = [];
+    writeJsonToStream(tree, {
+      write: c => chunks.push(c)
+    });
+
+    assert.equal(chunks.length, 10);
+    assert.equal(chunks.join(''), JSON.stringify(tree));
+  });
+
+  it('handles trees with shared object references identically to JSON.stringify', () => {
+    // traverse() returns the same JS object for every file that has already
+    // been visited (config.visited cache). The streaming writer must produce
+    // the same output as JSON.stringify for such trees.
+    const shared = {
+      'dep.js': {
+        'transitive.js': {}
+      }
+    };
+    const tree = {
+      'a.js': shared,
+      'b.js': shared
+    };
+
+    const output = collect(tree);
+    const parsed = JSON.parse(output);
+    const expectedA = {
+      'dep.js': {
+        'transitive.js': {}
+      }
+    };
+    const expectedB = {
+      'dep.js': {
+        'transitive.js': {}
+      }
+    };
+
+    assert.equal(output, JSON.stringify(tree));
+    assert.deepEqual(parsed['a.js'], expectedA);
+    assert.deepEqual(parsed['b.js'], expectedB);
+  });
+});


### PR DESCRIPTION
JSON.stringify buffers the entire serialized tree as a single string before writing anything. On large monorepos with many shared dependencies that string exceeds V8's ~512 MB string-length limit, crashing with "RangeError: Invalid string length".

Replace the console.log(JSON.stringify(tree)) call with a recursive streaming writer that emits JSON fragments directly to process.stdout in small chunks.

Fixes #141